### PR TITLE
Thread arena through remaining list_init callers (animation.h, gui.h, render_queue.h)

### DIFF
--- a/basic/ds/list.h
+++ b/basic/ds/list.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "../dbg.h"
 #include "../common.h"
+#include "../arena.h"
 
-//TODO: use arenas
 //TODO: bring better cache locality
 
 /*==============================================================================
@@ -13,26 +13,28 @@ typedef struct list_t {
 
     u64     len;                        // length of the list
     u8      *data;
-    u64     __capacity;
-    i64     __top;
-    u64     __elem_size;
-    char    __elem_type[MAX_TYPE_CHARACTER_LENGTH];
-    u64     __original_capacity;
-    bool    __are_values_pointers;     // This variable checks if the list is a list of pointers 
+    arena_t *arena;                     // NULL = malloc/free, non-NULL = arena allocator
+    struct {
+        u64     capacity;
+        i64     top;
+        u64     elem_size;
+        char    elem_type[MAX_TYPE_CHARACTER_LENGTH];
+        u64     original_capacity;
+    } internal;
 
 } list_t ;
 
 #define DEFAULT_LIST_STARTING_CAPACITY 4
 
-#define         list_init(TYPE)                                 __impl_list_init(DEFAULT_LIST_STARTING_CAPACITY, #TYPE, sizeof(TYPE))
+#define         list_init(TYPE, ARENA)                               list__internal__init(DEFAULT_LIST_STARTING_CAPACITY, #TYPE, sizeof(TYPE), ARENA)
 
-#define         list_append(PLIST, VALUE)                       __impl_list_append((PLIST), &(VALUE), sizeof(VALUE)) 
-#define         list_append_ptr(PLIST, PVALUE)                   __impl_list_append((PLIST), PVALUE, sizeof(void *)) 
+#define         list_append(PLIST, VALUE)                       list__internal__append((PLIST), &(VALUE), sizeof(VALUE)) 
+#define         list_append_ptr(PLIST, PVALUE)                   list__internal__append((PLIST), &(PVALUE), sizeof(void *)) 
 void            list_delete(list_t *list, const u64 index);
 void            list_clear(list_t *const list);
 void            list_combine(list_t *dest, const list_t *src);
-#define         list_get_size(PLIST)                             ((PLIST)->__elem_size * (PLIST)->len)
-#define         list_append_multiple(PLIST, ARRAY)              __impl_list_append_multiple((PLIST), (u8*)(ARRAY), sizeof((ARRAY)), sizeof((*ARRAY)))
+#define         list_get_size(PLIST)                             ((PLIST)->internal.elem_size * (PLIST)->len)
+#define         list_append_multiple(PLIST, ARRAY)              list__internal__append_multiple((PLIST), (u8*)(ARRAY), sizeof((ARRAY)), sizeof((*ARRAY)))
 
 void            list_dump(const list_t *list);
 void            list_print(const list_t *list, void (*print)(void*));
@@ -40,7 +42,7 @@ bool            list_is_init(const list_t * const self);
 
 #define         list_get_buffer(PLIST) (PLIST)->data
 void *          list_get_value(const list_t *list, const u64 index);
-#define         list_iterator(PLIST, ITER)                          __impl_list_iterator((PLIST), (ITER), list_iterator_index)
+#define         list_iterator(PLIST, ITER)                          list__internal__iterator((PLIST), (ITER), list_iterator_index)
 
 void            list_destroy(list_t *list);
 
@@ -51,8 +53,8 @@ void            list_destroy(list_t *list);
 
 #ifndef IGNORE_LIST_IMPLEMENTATION
 
-#define __impl_list_iterator(PLIST, ITER, IDX)\
-    if ((PLIST)->len != 0 && (PLIST)->__capacity != 0)\
+#define list__internal__iterator(PLIST, ITER, IDX)\
+    if ((PLIST)->len != 0 && (PLIST)->internal.capacity != 0)\
         for (void **(IDX) = 0, *(ITER) = (void *)list_get_value((PLIST), (u64)(IDX));\
             (u64)(IDX) < (PLIST)->len;\
             (IDX) = (void **)((u64)(IDX) + 1),\
@@ -62,70 +64,67 @@ void * list_get_value(const list_t *list, const u64 index)
 {
     assert(index < list->len);
 
-    if (list->__are_values_pointers)
-        return *(void **)(list->data + index * list->__elem_size);
-    else 
-        return (list->data + index * list->__elem_size);
+    return (list->data + index * list->internal.elem_size);
 }
 
 void list_clear(list_t *const list)
 {
     assert(list);
-    list->__top = -1;
+    list->internal.top = -1;
     list->len = 0;
-    memset(list->data, 0, list->__elem_size * list->__capacity);
-
+    memset(list->data, 0, list->internal.elem_size * list->internal.capacity);
 }
 
-list_t __impl_list_init(const u64 capacity, const char *elem_type, const u64 elem_size) 
+list_t list__internal__init(const u64 capacity, const char *elem_type, const u64 elem_size, arena_t *arena) 
 {
     assert(elem_type);
     assert(elem_size > 0);
 
-    bool flag = false;
     u32 len = strlen(elem_type);
     if (len > MAX_TYPE_CHARACTER_LENGTH - 1) eprint("variable name is too big, exceeded the 16 limit threshold\n");
-    if (elem_type[len - 1] == '*') flag = true;
 
     list_t o = {
-
         .len = 0,
-        .__capacity = capacity,
-        .data = (u8 *)calloc(capacity, elem_size),
-        .__top = -1,
-        .__elem_size = elem_size,
-        .__elem_type = {0},
-        .__original_capacity = capacity,
-        .__are_values_pointers = flag,
+        .data = arena ? (u8 *)arena_reserve(arena, capacity * elem_size) : (u8 *)calloc(capacity, elem_size),
+        .arena = arena,
+        .internal = {
+            .capacity = capacity,
+            .top = -1,
+            .elem_size = elem_size,
+            .elem_type = {0},
+            .original_capacity = capacity,
+        },
     };
 
-    u32 copy_len = flag ? (len - 1) : len;
+    u32 copy_len = len;
     if (copy_len >= MAX_TYPE_CHARACTER_LENGTH) copy_len = MAX_TYPE_CHARACTER_LENGTH - 1;
-    memcpy(o.__elem_type, elem_type, copy_len);
+    memcpy(o.internal.elem_type, elem_type, copy_len);
 
     return o;
 }
 
-void __impl_list_append(list_t *list, const void *value_addr, u64 value_size)
+void list__internal__append(list_t *list, const void *value_addr, u64 value_size)
 {
     assert(list);
     assert(value_addr);
-    if (value_size != list->__elem_size) eprint("trying to push a value of size %lu to slot of size %lu", value_size, list->__elem_size);
+    if (value_size != list->internal.elem_size) eprint("trying to push a value of size %lu to slot of size %lu", value_size, list->internal.elem_size);
 
-    if (list->__top == (i64)(list->__capacity - 1)) {
+    if (list->internal.top == (i64)(list->internal.capacity - 1)) {
 
-        list->__capacity = list->__capacity * 2;
-        list->data = (u8 *)realloc(list->data, list->__capacity * list->__elem_size);
-        //printf("Grew to %ld\n", list->__capacity);
+        u64 new_capacity = list->internal.capacity * 2;
+        if (list->arena) {
+            u8 *new_data = arena_reserve(list->arena, new_capacity * list->internal.elem_size);
+            memcpy(new_data, list->data, list->internal.capacity * list->internal.elem_size);
+            list->data = new_data;
+        } else {
+            list->data = (u8 *)realloc(list->data, new_capacity * list->internal.elem_size);
+        }
+        list->internal.capacity = new_capacity;
     }
 
-    list->len = ++list->__top + 1;
+    list->len = ++list->internal.top + 1;
 
-    if (!list->__are_values_pointers) {
-        memcpy(list->data + list->__top * list->__elem_size, value_addr, list->__elem_size);
-    } else {
-        ((void **)list->data)[list->__top] = (void *)value_addr;
-    }
+    memcpy(list->data + list->internal.top * list->internal.elem_size, value_addr, list->internal.elem_size);
 }
 
 
@@ -134,41 +133,39 @@ void __impl_list_append(list_t *list, const void *value_addr, u64 value_size)
 void list_delete(list_t *list, const u64 index)
 {
     assert(list);
-    if(list->__top == -1)           eprint("Trying to delete an element from an empty list\n");
-    if((i64)index > list->__top)    eprint("index (`%lu`) exceeds list length (`%lu`) ", index, list->__top);
+    if(list->internal.top == -1)           eprint("Trying to delete an element from an empty list\n");
+    if((i64)index > list->internal.top)    eprint("index (`%lu`) exceeds list length (`%lu`) ", index, list->internal.top);
 
-    if ((i64)index != list->__top) {
+    if ((i64)index != list->internal.top) {
 
-        memcpy(list->data + index * list->__elem_size, 
-                list->data + (index + 1) * list->__elem_size, 
-                list->__elem_size * (list->__top - index)); 
+        memcpy(list->data + index * list->internal.elem_size, 
+                list->data + (index + 1) * list->internal.elem_size, 
+                list->internal.elem_size * (list->internal.top - index)); 
     } 
 
-    list->len = --list->__top + 1;
+    list->len = --list->internal.top + 1;
 
-    if ((list->__capacity != list->__original_capacity) 
-            && (list->__top == (i64)((list->__capacity / 2) - 1))) { 
+    if (!list->arena
+            && (list->internal.capacity != list->internal.original_capacity) 
+            && (list->internal.top == (i64)((list->internal.capacity / 2) - 1))) { 
 
-        list->__capacity = list->__capacity / 2;
-        list->data = (u8 *)realloc(list->data, list->__capacity * list->__elem_size);
-        printf("Shrunk from %ld to %ld\n", list->__capacity * 2, list->__capacity);
+        list->internal.capacity = list->internal.capacity / 2;
+        list->data = (u8 *)realloc(list->data, list->internal.capacity * list->internal.elem_size);
+        printf("Shrunk from %ld to %ld\n", list->internal.capacity * 2, list->internal.capacity);
     }
 } 
 
 void list_print(const list_t *list, void (*print)(void*))
 {
     assert(list);
-    if (list->__top == -1) {
+    if (list->internal.top == -1) {
         printf("[]\n");
         return ;
     }
     printf("[ ");
     for (u64 i = 0; i < list->len; i++)
     {
-        if (list->__are_values_pointers)
-            print(*(void **)(list->data + i * list->__elem_size));
-        else 
-            print(list->data + i * list->__elem_size);
+        print(list->data + i * list->internal.elem_size);
     }
     printf("]\n");
 }
@@ -180,14 +177,14 @@ void list_dump(const list_t *list)
     printf("\n len = %ld\n arr = %p\n top = %ld\n capacity = %ld\n elem_size = %ld\n", 
             list->len, 
             list->data, 
-            list->__top, 
-            list->__capacity, 
-            list->__elem_size);
+            list->internal.top, 
+            list->internal.capacity, 
+            list->internal.elem_size);
 
     printf(" contents = [ ");
-    for (u64 i = 0; i < list->__capacity; i++)
+    for (u64 i = 0; i < list->internal.capacity; i++)
     {
-        printf("%p, ",list->data + i * list->__elem_size);
+        printf("%p, ",list->data + i * list->internal.elem_size);
     }
     printf("]\n");
 
@@ -195,25 +192,27 @@ void list_dump(const list_t *list)
 
 void list_destroy(list_t *list)
 {
-    free(list->data);
+    if (!list->arena) {
+        free(list->data);
+    }
     list->data = NULL;
-    list->__capacity = 0;
-    list->__top = -1;
+    list->internal.capacity = 0;
+    list->internal.top = -1;
     list->len = 0;
-    list->__elem_size = 0;
+    list->internal.elem_size = 0;
 }
 
 void list_combine(list_t *dest, const list_t *src)
 {
-    if (strcmp(dest->__elem_type, src->__elem_type) != 0)
+    if (strcmp(dest->internal.elem_type, src->internal.elem_type) != 0)
         eprint("destination (%s) and src (%s) types are different", 
-                dest->__elem_type, src->__elem_type);
+                dest->internal.elem_type, src->internal.elem_type);
 
     list_iterator(src, iter)
-        __impl_list_append(dest, iter, dest->__elem_size);
+        list__internal__append(dest, iter, dest->internal.elem_size);
 }
 
-void __impl_list_append_multiple(
+void list__internal__append_multiple(
         list_t *slot, 
         const u8 *arr, 
         const u64 arr_size, 
@@ -227,7 +226,7 @@ void __impl_list_append_multiple(
     const u32 arr_len = (arr_size / elem_size);
     for (u32 i = 0; i < arr_len; i++)
     {
-        __impl_list_append(
+        list__internal__append(
                 slot, 
                 arr + (elem_size * i), 
                 elem_size);
@@ -237,6 +236,6 @@ void __impl_list_append_multiple(
 
 bool list_is_init(const list_t *const self)
 {
-    return self->__original_capacity > 0;
+    return self->internal.original_capacity > 0;
 }
 #endif

--- a/gfx/model/animation.h
+++ b/gfx/model/animation.h
@@ -45,7 +45,7 @@ void                animator_destroy(animator_t *self);
 animator_t animator_init(void)
 {
     return (animator_t ){
-        .animations = list_init(animation_t)
+        .animations = list_init(animation_t, NULL)
     };
 }
 
@@ -74,7 +74,7 @@ animation_t __animation_init(const char *name, const f32 duration, const f32 tic
         .name = name,
         .duration = duration,
         .ticks_per_second = ticks_per_second,
-        .channels = list_init(node_anim_t)
+        .channels = list_init(node_anim_t, NULL)
     };
 }
 
@@ -143,9 +143,9 @@ void __load_channels(const struct aiAnimation *animation, animation_t *self)
         const struct aiNodeAnim *node = animation->mChannels[i];
         node_anim_t n = {
             .node_name = node->mNodeName.data,
-            .position_keys = list_init(position_key_t),
-            .rotation_keys = list_init(rotation_key_t),
-            .scaling_keys = list_init(scaling_key_t),
+            .position_keys = list_init(position_key_t, NULL),
+            .rotation_keys = list_init(rotation_key_t, NULL),
+            .scaling_keys = list_init(scaling_key_t, NULL),
         };
 
         __load_channel_positions(node, &n.position_keys);

--- a/gfx/model/animation.h
+++ b/gfx/model/animation.h
@@ -37,15 +37,15 @@ typedef struct {
 } animator_t;
 
 
-animator_t          animator_init(void);
-void                animator_load_all_animations(animator_t *self, const struct aiScene *scene);
+animator_t          animator_init(arena_t *arena);
+void                animator_load_all_animations(animator_t *self, const struct aiScene *scene, arena_t *arena);
 animation_t *       animator_get_animation(const animator_t *self, const char *animation_label);
 void                animator_destroy(animator_t *self);
 
-animator_t animator_init(void)
+animator_t animator_init(arena_t *arena)
 {
     return (animator_t ){
-        .animations = list_init(animation_t, NULL)
+        .animations = list_init(animation_t, arena)
     };
 }
 
@@ -68,13 +68,13 @@ animation_t * animator_get_animation(const animator_t *self, const char *label)
     ASSERT(false);
 }
 
-animation_t __animation_init(const char *name, const f32 duration, const f32 ticks_per_second)
+animation_t __animation_init(const char *name, const f32 duration, const f32 ticks_per_second, arena_t *arena)
 {
     return (animation_t ) {
         .name = name,
         .duration = duration,
         .ticks_per_second = ticks_per_second,
-        .channels = list_init(node_anim_t, NULL)
+        .channels = list_init(node_anim_t, arena)
     };
 }
 
@@ -136,16 +136,16 @@ void __load_channel_scaling(const struct aiNodeAnim *node, list_t *scal)
     }
 }
 
-void __load_channels(const struct aiAnimation *animation, animation_t *self)
+void __load_channels(const struct aiAnimation *animation, animation_t *self, arena_t *arena)
 {
     for (u32 i = 0; i < animation->mNumChannels; i++)
     {
         const struct aiNodeAnim *node = animation->mChannels[i];
         node_anim_t n = {
             .node_name = node->mNodeName.data,
-            .position_keys = list_init(position_key_t, NULL),
-            .rotation_keys = list_init(rotation_key_t, NULL),
-            .scaling_keys = list_init(scaling_key_t, NULL),
+            .position_keys = list_init(position_key_t, arena),
+            .rotation_keys = list_init(rotation_key_t, arena),
+            .scaling_keys = list_init(scaling_key_t, arena),
         };
 
         __load_channel_positions(node, &n.position_keys);
@@ -156,7 +156,7 @@ void __load_channels(const struct aiAnimation *animation, animation_t *self)
     }
 }
 
-void animator_load_all_animations(animator_t *self, const struct aiScene *scene)
+void animator_load_all_animations(animator_t *self, const struct aiScene *scene, arena_t *arena)
 {
     for (u32 i = 0; i < scene->mNumAnimations; i++)
     {
@@ -165,9 +165,10 @@ void animator_load_all_animations(animator_t *self, const struct aiScene *scene)
         animation_t item = __animation_init(
             ai->mName.data,
             ai->mDuration, 
-            ai->mTicksPerSecond);
+            ai->mTicksPerSecond,
+            arena);
 
-        __load_channels(ai, &item);
+        __load_channels(ai, &item, arena);
 
         list_append(&self->animations, item);
     }

--- a/gfx/model/assimp.h
+++ b/gfx/model/assimp.h
@@ -380,7 +380,7 @@ glmodel_t glmodel_init(const char *filepath)
     o.textures = list_init(gltexture2d_t, &o.arena);
     o.colors = list_init(vec4f_t, &o.arena);
     o.bone_infos = list_init(boneinfo_t, &o.arena);
-    o.animator = animator_init();
+    o.animator = animator_init(&o.arena);
     o.current_time = 0.0f;
     o.internal.root_channel_idx = -1;
 
@@ -405,7 +405,7 @@ glmodel_t glmodel_init(const char *filepath)
     assimp__internal_glmesh_processScene(&o, scene);
 
     //load all animations
-    animator_load_all_animations(&o.animator, scene);
+    animator_load_all_animations(&o.animator, scene, &o.arena);
 
 
     //NOTE: this to cache the root channel idx to get the root position of the model during an animation

--- a/gfx/model/assimp.h
+++ b/gfx/model/assimp.h
@@ -18,8 +18,7 @@
 #include <poglib/external/assimp/include/assimp/postprocess.h>
 #include <poglib/external/assimp/include/assimp/scene.h>
 
-//TODO: materials implementation is fucked - need to learn how do this 
-//TODO: arena support
+//TODO: materials implementation is fucked - need to learn how do this
 
 #define MAX_BONES 128
 
@@ -326,7 +325,7 @@ void assimp__internal_glmesh_processScene(glmodel_t *self, const struct aiScene 
     {
         struct aiMesh *mesh = scene->mMeshes[mesh_index];
 
-        self->transforms[mesh_index] = list_init(matrix4f_t);
+        self->transforms[mesh_index] = list_init(matrix4f_t, &self->arena);
 
         // Process mesh
         const glmesh_t m = assimp__internal_glmesh_processMesh(mesh);
@@ -376,13 +375,13 @@ glmodel_t glmodel_init(const char *filepath)
     ASSERT(strlen(filepath) < ARRAY_LEN(o.filepath));
     memcpy(o.filepath, filepath, strlen(filepath));
     o.directory_path = str_get_directory_path(filepath);
-    o.meshes = list_init(glmesh_t);
-    o.textures = list_init(gltexture2d_t);
-    o.colors = list_init(vec4f_t);
-    o.bone_infos = list_init(boneinfo_t);
+    o.arena = arena_init(NULL, 2 * MB);
+    o.meshes = list_init(glmesh_t, &o.arena);
+    o.textures = list_init(gltexture2d_t, &o.arena);
+    o.colors = list_init(vec4f_t, &o.arena);
+    o.bone_infos = list_init(boneinfo_t, &o.arena);
     o.animator = animator_init();
     o.current_time = 0.0f;
-    o.arena = arena_init(NULL, 2 * MB);
     o.internal.root_channel_idx = -1;
 
     logging("Loading model %s ...", filepath);

--- a/gui.h
+++ b/gui.h
@@ -151,39 +151,31 @@ void    gui_destroy(gui_t *self);
 
 gui_t gui_init(arena_t * const arena, const ui_region_t starting_region)
 {
-    return (gui_t){
-        .shader =  glshader_init(
-            str(POGLIB_ROOT_DIR"/gui/uishader-vtx.glsl"), 
-            str(POGLIB_ROOT_DIR"/gui/uishader-frag.glsl"), 
-            (gluniform_registry_t) {
-                .count = 1,
-                .data = {
-                    [0] = {
-                        .name = str_lit("projection"),
-                        .type = GL_UNIFORM_TYPE_MATRIX4F
-                    }
+    gui_t o = {0};
+    o.shader =  glshader_init(
+        str(POGLIB_ROOT_DIR"/gui/uishader-vtx.glsl"), 
+        str(POGLIB_ROOT_DIR"/gui/uishader-frag.glsl"), 
+        (gluniform_registry_t) {
+            .count = 1,
+            .data = {
+                [0] = {
+                    .name = str_lit("projection"),
+                    .type = GL_UNIFORM_TYPE_MATRIX4F
                 }
-            },
-            arena
-        ),
-        .freetypefont = glfreetypefont_init(DEFAULT_FONT_ROBOTO_MEDIUM_FILEPATH, 14, true),
-        .arena = arena_init(arena, 1 * MB),
-        .gfx = {
-            .instanced_attrs = list_init(ui_attr_t, NULL),
+            }
         },
-        .internal = {
-            .layout_cursor_stack = {
-                .top = 0,
-                .buffer = {
-                    [0] = (layout_ctx_t){
-                        .max_row_height = 0,
-                        .region = starting_region,
-                        .starting_region = starting_region
-                    }
-                },
-            },
-        }
+        arena
+    );
+    o.freetypefont = glfreetypefont_init(DEFAULT_FONT_ROBOTO_MEDIUM_FILEPATH, 14, true);
+    o.arena = arena_init(arena, 1 * MB);
+    o.gfx.instanced_attrs = list_init(ui_attr_t, &o.arena);
+    o.internal.layout_cursor_stack.top = 0;
+    o.internal.layout_cursor_stack.buffer[0] = (layout_ctx_t){
+        .max_row_height = 0,
+        .region = starting_region,
+        .starting_region = starting_region
     };
+    return o;
 }
 
 

--- a/gui.h
+++ b/gui.h
@@ -169,7 +169,7 @@ gui_t gui_init(arena_t * const arena, const ui_region_t starting_region)
         .freetypefont = glfreetypefont_init(DEFAULT_FONT_ROBOTO_MEDIUM_FILEPATH, 14, true),
         .arena = arena_init(arena, 1 * MB),
         .gfx = {
-            .instanced_attrs = list_init(ui_attr_t),
+            .instanced_attrs = list_init(ui_attr_t, NULL),
         },
         .internal = {
             .layout_cursor_stack = {

--- a/pipeline/render/common.h
+++ b/pipeline/render/common.h
@@ -17,6 +17,7 @@ typedef enum {
 
 typedef struct {
     list_t buckets[MAX_RENDER_BUCKETS_ALLOWED];
+    arena_t arena;
     struct {
         glinstancebuffer_t instancebuffer;
     } internal;

--- a/pipeline/render/render_queue.h
+++ b/pipeline/render/render_queue.h
@@ -9,7 +9,7 @@
 #include "poglib/pipeline/render/render_command.h"
 #include "poglib/util/asset.h"
 
-renderqueue_t       renderqueue_init(void);
+renderqueue_t       renderqueue_init(arena_t *arena);
 void                renderqueue_pass_command(renderqueue_t * const self, const rendercommand_t command);
 void                renderqueue_dispatch(renderqueue_t * const self);
 void                renderqueue_flush(renderqueue_t * const self);
@@ -22,10 +22,11 @@ bool renderqueue__internal_check_for_batchable_commands(renderqueue_t * const qu
 void renderqueue__internal_add_to_bucket(list_t * const render_commands, const rendercommand_t command);
 void rendercommand__internal_shader_upload_uniforms(const rendercommand_t * const command);
 
-renderqueue_t renderqueue_init(void)
+renderqueue_t renderqueue_init(arena_t *arena)
 {
     return (renderqueue_t) {
         .buckets = {0},
+        .arena = arena_init(arena, 2 * MB),
         .internal = {
             .instancebuffer = glinstancebuffer_init(2 * MB),
         }
@@ -34,7 +35,7 @@ renderqueue_t renderqueue_init(void)
 
 void renderqueue__internal_bucket_init_and_add_command(renderqueue_t *const self, const rendercommand_t command, const u16 idx)
 {
-    self->buckets[idx] = list_init(rendercommand_t, NULL);
+    self->buckets[idx] = list_init(rendercommand_t, &self->arena);
     list_append(&self->buckets[idx], command);
 }
 
@@ -75,6 +76,7 @@ void renderqueue_destroy(renderqueue_t * const self)
         list_destroy(&self->buckets[idx]);
     }
     glinstancebuffer_destroy(&self->internal.instancebuffer);
+    arena_destroy(&self->arena);
 }
 
 void renderqueue__internal_validate_command(const rendercommand_t command)

--- a/pipeline/render/render_queue.h
+++ b/pipeline/render/render_queue.h
@@ -34,7 +34,7 @@ renderqueue_t renderqueue_init(void)
 
 void renderqueue__internal_bucket_init_and_add_command(renderqueue_t *const self, const rendercommand_t command, const u16 idx)
 {
-    self->buckets[idx] = list_init(rendercommand_t);
+    self->buckets[idx] = list_init(rendercommand_t, NULL);
     list_append(&self->buckets[idx], command);
 }
 

--- a/poggen.h
+++ b/poggen.h
@@ -96,7 +96,7 @@ poggen_t * poggen_init(application_t * const app, const poggen_config_t config)
         },
         .systems = {
             .assets      = assetmanager_init(&output->bg_task_manager),
-            .renderqueue = renderqueue_init(),
+            .renderqueue = renderqueue_init(&arena),
             .physics     = config.enable_physics 
                            ? (poggen__internal_physics_t){
                                .phy_simulation_started = false,

--- a/test/ds/list/main.c
+++ b/test/ds/list/main.c
@@ -1,0 +1,397 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include <poglib/basic.h>
+
+#undef TEST
+
+static int total_tests = 0;
+static int passed_tests = 0;
+
+#define TEST(name) do { \
+    total_tests++; \
+    printf("  %s ... ", name); \
+    fflush(stdout); \
+} while(0)
+
+#define PASS() do { \
+    passed_tests++; \
+    printf("PASS\n"); \
+} while(0)
+
+#define FAIL(msg) do { \
+    printf("FAILED (%s)\n", msg); \
+    return; \
+} while(0)
+
+void test_malloc_init(void)
+{
+    TEST("malloc init");
+    list_t l = list_init(int, NULL);
+    if (!list_is_init(&l)) FAIL("not initialized");
+    if (l.arena != NULL) FAIL("arena should be NULL");
+    if (l.data == NULL) FAIL("data is NULL");
+    list_destroy(&l);
+    PASS();
+}
+
+void test_malloc_append_read(void)
+{
+    TEST("malloc append and read");
+    list_t l = list_init(int, NULL);
+    for (int i = 0; i < 10; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    if (l.len != 10) FAIL("wrong length");
+    for (int i = 0; i < 10; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != i) FAIL("wrong value");
+    }
+    list_destroy(&l);
+    PASS();
+}
+
+void test_malloc_append_ptr(void)
+{
+    TEST("malloc append_ptr");
+    list_t l = list_init(char *, NULL);
+    char *strings[] = {"hello", "world", "foo"};
+    for (int i = 0; i < 3; i++)
+        list_append_ptr(&l, strings[i]);
+    if (l.len != 3) FAIL("wrong length");
+    for (int i = 0; i < 3; i++) {
+        char **vp = (char **)list_get_value(&l, i);
+        if (*vp != strings[i]) FAIL("wrong pointer");
+    }
+    list_destroy(&l);
+    PASS();
+}
+
+void test_malloc_delete(void)
+{
+    TEST("malloc delete");
+    list_t l = list_init(int, NULL);
+    for (int i = 0; i < 5; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    list_delete(&l, 2);
+    if (l.len != 4) FAIL("wrong length after delete");
+    int expected[] = {0, 1, 3, 4};
+    for (int i = 0; i < 4; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != expected[i]) FAIL("wrong value after delete");
+    }
+    list_destroy(&l);
+    PASS();
+}
+
+void test_malloc_clear(void)
+{
+    TEST("malloc clear");
+    list_t l = list_init(int, NULL);
+    for (int i = 0; i < 5; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    list_clear(&l);
+    if (l.len != 0) FAIL("len should be 0 after clear");
+    if (l.internal.top != -1) FAIL("top should be -1 after clear");
+    list_destroy(&l);
+    PASS();
+}
+
+void test_malloc_combine(void)
+{
+    TEST("malloc combine");
+    list_t a = list_init(int, NULL);
+    list_t b = list_init(int, NULL);
+    for (int i = 0; i < 3; i++) { int v = i; list_append(&a, v); }
+    for (int i = 3; i < 6; i++) { int v = i; list_append(&b, v); }
+    list_combine(&a, &b);
+    if (a.len != 6) FAIL("wrong length after combine");
+    for (int i = 0; i < 6; i++) {
+        int *v = (int *)list_get_value(&a, i);
+        if (*v != i) FAIL("wrong value after combine");
+    }
+    list_destroy(&a);
+    list_destroy(&b);
+    PASS();
+}
+
+void test_arena_init(void)
+{
+    TEST("arena init");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    if (!list_is_init(&l)) FAIL("not initialized");
+    if (l.arena != &arena) FAIL("arena pointer mismatch");
+    if (l.data == NULL) FAIL("data is NULL");
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_append_read(void)
+{
+    TEST("arena append and read");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    for (int i = 0; i < 10; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    if (l.len != 10) FAIL("wrong length");
+    for (int i = 0; i < 10; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != i) FAIL("wrong value");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_grow(void)
+{
+    TEST("arena grow past initial capacity");
+    arena_t arena = arena_init(NULL, 16384);
+    list_t l = list_init(int, &arena);
+    int n = 100;
+    for (int i = 0; i < n; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    if (l.len != (u64)n) FAIL("wrong length after growth");
+    for (int i = 0; i < n; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != i) FAIL("wrong value after growth");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_delete_no_shrink(void)
+{
+    TEST("arena delete does not shrink capacity");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    for (int i = 0; i < 8; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    u64 cap_before = l.internal.capacity;
+    list_delete(&l, 3);
+    list_delete(&l, 3);
+    list_delete(&l, 3);
+    if (l.internal.capacity != cap_before) FAIL("capacity should not shrink with arena");
+    int expected[] = {0, 1, 2, 6, 7};
+    if (l.len != 5) FAIL("wrong length after deletes");
+    for (int i = 0; i < 5; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != expected[i]) FAIL("wrong value after deletes");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_clear(void)
+{
+    TEST("arena clear and refill");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    for (int i = 0; i < 10; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    list_clear(&l);
+    if (l.len != 0) FAIL("len should be 0");
+    if (l.internal.top != -1) FAIL("top should be -1");
+    for (int i = 0; i < 10; i++) {
+        int v = i * 2;
+        list_append(&l, v);
+    }
+    if (l.len != 10) FAIL("wrong length after re-fill");
+    for (int i = 0; i < 10; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != i * 2) FAIL("wrong value after clear+refill");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_multiple_lists(void)
+{
+    TEST("arena multiple lists from same arena");
+    arena_t arena = arena_init(NULL, 16384);
+    list_t ints = list_init(int, &arena);
+    list_t floats = list_init(float, &arena);
+    for (int i = 0; i < 20; i++) {
+        int vi = i;
+        float vf = (float)i * 1.5f;
+        list_append(&ints, vi);
+        list_append(&floats, vf);
+    }
+    if (ints.len != 20) FAIL("wrong ints length");
+    if (floats.len != 20) FAIL("wrong floats length");
+    for (int i = 0; i < 20; i++) {
+        int *iv = (int *)list_get_value(&ints, i);
+        float *fv = (float *)list_get_value(&floats, i);
+        if (*iv != i) FAIL("wrong int value");
+        if (*fv != (float)i * 1.5f) FAIL("wrong float value");
+    }
+    list_destroy(&ints);
+    list_destroy(&floats);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_pointer_type(void)
+{
+    TEST("arena pointer type list");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(char *, &arena);
+    char *words[] = {"alpha", "beta", "gamma", "delta"};
+    for (int i = 0; i < 4; i++)
+        list_append_ptr(&l, words[i]);
+    if (l.len != 4) FAIL("wrong length");
+    for (int i = 0; i < 4; i++) {
+        char **vp = (char **)list_get_value(&l, i);
+        if (*vp != words[i]) FAIL("wrong pointer value");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_struct_type(void)
+{
+    TEST("arena struct type");
+    typedef struct {
+        int x, y, z;
+        char label[16];
+    } point_t;
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(point_t, &arena);
+    for (int i = 0; i < 10; i++) {
+        point_t p = {i, i*2, i*3, "pt"};
+        list_append(&l, p);
+    }
+    if (l.len != 10) FAIL("wrong length");
+    for (int i = 0; i < 10; i++) {
+        point_t *p = (point_t *)list_get_value(&l, i);
+        if (p->x != i || p->y != i*2 || p->z != i*3) FAIL("wrong struct field");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_append_multiple(void)
+{
+    TEST("arena append_multiple");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    int data[] = {10, 20, 30, 40, 50};
+    list_append_multiple(&l, data);
+    if (l.len != 5) FAIL("wrong length");
+    for (int i = 0; i < 5; i++) {
+        int *v = (int *)list_get_value(&l, i);
+        if (*v != data[i]) FAIL("wrong value");
+    }
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_destroy_empty(void)
+{
+    TEST("arena destroy empty list");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    list_destroy(&l);
+    PASS();
+    arena_destroy(&arena);
+}
+
+void test_malloc_destroy_empty(void)
+{
+    TEST("malloc destroy empty list");
+    list_t l = list_init(int, NULL);
+    list_destroy(&l);
+    PASS();
+}
+
+void test_arena_data_within_arena(void)
+{
+    TEST("arena data lives in arena memory");
+    arena_t arena = arena_init(NULL, 4096);
+    list_t l = list_init(int, &arena);
+    u8 *arena_start = arena.memory;
+    u8 *arena_end = arena.memory + arena.capacity;
+    for (int i = 0; i < 10; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    if (l.data < arena_start || l.data >= arena_end)
+        FAIL("list data is not within arena memory");
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+void test_arena_growth_uses_arena(void)
+{
+    TEST("arena growth allocations are in arena");
+    arena_t arena = arena_init(NULL, 16384);
+    list_t l = list_init(int, &arena);
+    u8 *arena_start = arena.memory;
+    u8 *arena_end = arena.memory + arena.capacity;
+    for (int i = 0; i < 500; i++) {
+        int v = i;
+        list_append(&l, v);
+    }
+    if (l.data < arena_start || l.data >= arena_end)
+        FAIL("grown data is not within arena memory");
+    list_destroy(&l);
+    arena_destroy(&arena);
+    PASS();
+}
+
+int main(void)
+{
+    printf("========================================\n");
+    printf("   LIST ARENA INTEGRATION TESTS\n");
+    printf("========================================\n\n");
+    printf("--- malloc mode (backward compat) ---\n");
+    test_malloc_init();
+    test_malloc_append_read();
+    test_malloc_append_ptr();
+    test_malloc_delete();
+    test_malloc_clear();
+    test_malloc_combine();
+    test_malloc_destroy_empty();
+
+    printf("\n--- arena mode ---\n");
+    test_arena_init();
+    test_arena_append_read();
+    test_arena_grow();
+    test_arena_delete_no_shrink();
+    test_arena_clear();
+    test_arena_multiple_lists();
+    test_arena_pointer_type();
+    test_arena_struct_type();
+    test_arena_append_multiple();
+    test_arena_destroy_empty();
+    test_arena_data_within_arena();
+    test_arena_growth_uses_arena();
+
+    printf("\n========================================\n");
+    printf("  %d / %d tests passed\n", passed_tests, total_tests);
+    printf("========================================\n");
+    return passed_tests == total_tests ? 0 : 1;
+}

--- a/test/ds/list/run.sh
+++ b/test/ds/list/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+POGLIB_ROOT=$(dirname "$0")/../../..
+POGLIB_DIR=$(cd "$POGLIB_ROOT" && pwd)
+gcc -I"$POGLIB_DIR"/.. -I"$POGLIB_DIR" -std=c11 -g -g3 -O0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-sign-compare -Wno-type-limits -Wno-format -pthread main.c -o a.out && echo "Compiled successfully"


### PR DESCRIPTION
Closes #11

Updates all `list_init(TYPE, NULL)` call sites outside assimp.h to use the owning struct's arena.

**gfx/model/animation.h** - `animator_init()`, `__animation_init()`, and `__load_channels()` now take an `arena_t *` parameter. The arena is threaded from `glmodel_init()` (`&o.arena`) through `animator_load_all_animations()` and into every `list_init(...)` call (animation_t, node_anim_t, position_key_t, rotation_key_t, scaling_key_t).

**gui.h** - `gui_init()` was restructured from a single compound literal to zero-init + field-by-field assignment so that `&o.arena` can be passed to `list_init(ui_attr_t, &o.arena)`.

**pipeline/render/render_queue.h + common.h** - `renderqueue_t` gains an `arena_t arena` field. `renderqueue_init()` now takes an `arena_t *` parameter and creates a sub-arena. Bucket lists are initialized with `list_init(rendercommand_t, &self->arena)`. `arena_destroy()` is called in `renderqueue_destroy()`.

**Note:** Builds on top of PR #10 (the `list_init(TYPE, ARENA)` API). Merge #10 first.
