### PR TITLE
fix: pass collider dimension in jolt userdata + bump arena size

### DIFF
--- a/ecs/component/colliderbatchqueue.h
+++ b/ecs/component/colliderbatchqueue.h
@@ -151,6 +151,7 @@ void colliderbatchqueue_upload_to_jolt(colliderbatchqueue_t *const self)
 
                 const ecs_collider_jolt_userdata_t userdata = {
                     .objectlayertype = collider->object_layer_type,
+                    .dimension = collider->dim,
 #ifdef DEBUG
                     .internal = {
                         .ecs_collider = collider

--- a/ecs/component/types.h
+++ b/ecs/component/types.h
@@ -164,6 +164,7 @@ struct ecs_component_collider_t {
 //expand this struct further
 struct ecs_collider_jolt_userdata_t {
     JPH_ObjectLayer objectlayertype;
+    collider_shape_dimension_t dimension;
 
 #ifdef DEBUG
     struct {

--- a/poggen.h
+++ b/poggen.h
@@ -46,7 +46,7 @@ typedef struct poggen_t {
 
 global poggen_t *global_engine = NULL;
 
-poggen_t *                          poggen_init(application_t * const app, const poggen_config_t config);
+poggen_t *                          poggen_init(application_t *const app, const poggen_config_t config);
 #define                             poggen_add_scene(PGEN, SCENE_NAME)                          poggen__internal_add_scene((PGEN), scene__internal_init(SCENE_NAME))
 void                                poggen_remove_scene(poggen_t *self, str_t label);
 void                                poggen_change_scene(poggen_t *self, str_t scene_label);
@@ -77,14 +77,14 @@ window_t * poggen_get_window(const poggen_t *self)
     return application_get_window(self->handle.app);
 }
 
-poggen_t * poggen_init(application_t * const app, const poggen_config_t config)
+poggen_t * poggen_init(application_t *const app, const poggen_config_t config)
 {
     if (!global_window)     eprint("A window is required to run poggen\n");
     if (global_engine)      eprint("Trying to initialize a second `poggen` in the same instance");
 
     poggen_t *output = (poggen_t *)calloc(1, sizeof(poggen_t ));
     ASSERT(output);
-    arena_t arena = arena_init(&app->handle.arena, 2 * MB);
+    arena_t arena = arena_init(&app->handle.arena, 5 * MB);
     *output = (poggen_t ){
         .config             = config,
         .scenes             = hashtable_init(MAX_SCENES_ALLOWED, HT_KEY_TYPE_STR, (ht_value_type){ .size = sizeof(scene_t), .type = HT_STORAGE_BY_REFERENCE }, &app->handle.arena),


### PR DESCRIPTION
## Summary

Fixes startup crash after merging arena integration PRs (#10, #13).

## Changes

- **ecs/component/types.h**: Add `collider_shape_dimension_t dimension` field to `ecs_collider_jolt_userdata_t` so Jolt callbacks can identify collider shape types at runtime
- **ecs/component/colliderbatchqueue.h**: Pass `collider->dim` when initializing Jolt userdata
- **poggen.h**: Bump init arena from 2MB → 5MB to prevent arena exhaustion crash at startup. Also minor formatting cleanup.

## Root Cause

After threading arenas through `list.h`, `renderqueue`, `animator`, and `glmodel`, the 2MB arena in `poggen_init` was insufficient to cover all allocations during engine startup. The dimension field was missing from the Jolt userdata struct, preventing shape identification in collision callbacks.