### PR TITLE
feat: SDL2 game controller support

### DIFF
--- a/application/window/sdl_window.h
+++ b/application/window/sdl_window.h
@@ -91,6 +91,16 @@ typedef struct window_t {
     } keyboard;
 
     struct {
+        bool                is_connected;
+        SDL_GameController  *handle;
+        SDL_JoystickID      instance_id;
+        bool                button_just_pressed[SDL_CONTROLLER_BUTTON_MAX];
+        bool                button_is_held[SDL_CONTROLLER_BUTTON_MAX];
+        bool                button_released[SDL_CONTROLLER_BUTTON_MAX];
+        i16                 axis[SDL_CONTROLLER_AXIS_MAX];
+    } controller;
+
+    struct {
         bool                is_active;
         struct window_t     *window;        // Holds subwindow address
     } subwindow;
@@ -127,6 +137,12 @@ bool                window_mouse_wheel_is_scroll_up(const window_t *const w);
 bool                window_mouse_wheel_is_scroll_down(const window_t *const w);
 bool                window_mouse_wheel_is_scroll_left(const window_t *const w);
 bool                window_mouse_wheel_is_scroll_right(const window_t *const w);
+
+bool                window_controller_is_connected(window_t *window);
+bool                window_controller_button_just_pressed(window_t *window, SDL_GameControllerButton button);
+bool                window_controller_button_is_held(window_t *window, SDL_GameControllerButton button);
+bool                window_controller_button_is_pressed(window_t *window, SDL_GameControllerButton button);
+i16                 window_controller_get_axis_value(window_t *window, SDL_GameControllerAxis axis);
 
 #define             window_mouse_get_norm_position(PWINDOW)                     (PWINDOW)->mouse.norm_position
 #define             window_mouse_get_position(PWINDOW)                          (PWINDOW)->mouse.position
@@ -249,6 +265,52 @@ bool window_mouse_wheel_is_scroll_right(const window_t *const w)
 bool window_mouse_wheel_is_scroll_left(const window_t *const w)
 {
     return w->mouse.wheel.state == SDL_MOUSEWHEEL_LEFT;
+}
+
+bool window_controller_is_connected(window_t *window)
+{
+    return window->controller.is_connected;
+}
+
+bool window_controller_button_just_pressed(window_t *window, SDL_GameControllerButton button)
+{
+    return window->controller.button_just_pressed[button];
+}
+
+bool window_controller_button_is_held(window_t *window, SDL_GameControllerButton button)
+{
+    return window->controller.button_is_held[button];
+}
+
+bool window_controller_button_is_pressed(window_t *window, SDL_GameControllerButton button)
+{
+    return window->controller.button_just_pressed[button]
+        || window->controller.button_is_held[button];
+}
+
+i16 window_controller_get_axis_value(window_t *window, SDL_GameControllerAxis axis)
+{
+    return window->controller.axis[axis];
+}
+
+INTERNAL void __controller_handle_button(window_t *window, SDL_GameControllerButton button, bool down)
+{
+    if (down) {
+        if (window->controller.button_is_held[button]) {
+            return;
+        }
+        if (window->controller.button_just_pressed[button]) {
+            window->controller.button_is_held[button] = true;
+            window->controller.button_just_pressed[button] = false;
+        } else {
+            window->controller.button_just_pressed[button] = true;
+            window->controller.button_is_held[button] = false;
+        }
+    } else {
+        window->controller.button_just_pressed[button] = false;
+        window->controller.button_is_held[button] = false;
+        window->controller.button_released[button] = true;
+    }
 }
 
 #define __impl_window_subwindow_gl_render_begin(PWINDOW) do {\
@@ -425,6 +487,19 @@ window_t * window_init(const char *title, u64 width, u64 height, const u32 flags
 #endif
 
     if (SDL_Init(flags) == -1) eprint("SDL Error: %s\n", SDL_GetError());
+
+    {
+        int num_joysticks = SDL_NumJoysticks();
+        if (num_joysticks > 0) {
+            win.controller.handle = SDL_GameControllerOpen(0);
+            if (win.controller.handle) {
+                win.controller.is_connected = true;
+                win.controller.instance_id = SDL_JoystickInstanceID(
+                    SDL_GameControllerGetJoystick(win.controller.handle));
+                SDL_Log("Controller connected: %s\n", SDL_GameControllerName(win.controller.handle));
+            }
+        }
+    }
 
     win.__sdl_window = SDL_CreateWindow(
             win.title, 
@@ -883,6 +958,57 @@ void window_poll_input_events(window_t *window)
                 __keyboard_update_buffers(window, SDL_KEYUP, event->key.keysym.scancode);
             break;
 
+            case SDL_CONTROLLERDEVICEADDED:
+            {
+                SDL_GameController *ctrl = SDL_GameControllerOpen(event->cdevice.which);
+                if (ctrl) {
+                    if (window->controller.is_connected) {
+                        SDL_GameControllerClose(ctrl);
+                    } else {
+                        window->controller.handle = ctrl;
+                        window->controller.is_connected = true;
+                        window->controller.instance_id = SDL_JoystickInstanceID(
+                            SDL_GameControllerGetJoystick(ctrl));
+                        SDL_Log("Controller connected: %s\n", SDL_GameControllerName(ctrl));
+                    }
+                }
+            } break;
+
+            case SDL_CONTROLLERDEVICEREMOVED:
+            {
+                if (window->controller.is_connected &&
+                    window->controller.instance_id == event->cdevice.which) {
+                    SDL_GameControllerClose(window->controller.handle);
+                    window->controller.handle = NULL;
+                    window->controller.is_connected = false;
+                    memset(window->controller.button_just_pressed, 0, sizeof(window->controller.button_just_pressed));
+                    memset(window->controller.button_is_held, 0, sizeof(window->controller.button_is_held));
+                    memset(window->controller.axis, 0, sizeof(window->controller.axis));
+                    SDL_Log("Controller disconnected\n");
+                }
+            } break;
+
+            case SDL_CONTROLLERBUTTONDOWN:
+            {
+                if (window->controller.is_connected) {
+                    __controller_handle_button(window, event->cbutton.button, true);
+                }
+            } break;
+
+            case SDL_CONTROLLERBUTTONUP:
+            {
+                if (window->controller.is_connected) {
+                    __controller_handle_button(window, event->cbutton.button, false);
+                }
+            } break;
+
+            case SDL_CONTROLLERAXISMOTION:
+            {
+                if (window->controller.is_connected) {
+                    window->controller.axis[event->caxis.axis] = event->caxis.value;
+                }
+            } break;
+
             //default:
                 //SDL_ShowSimpleMessageBox(0, "ERROR", "Key not accounted for", window->__sdl_window);
                 //window->is_open = false;
@@ -974,6 +1100,12 @@ void window_destroy(void)
         window->subwindow.is_active = false;
     }
 
+    if (window->controller.is_connected && window->controller.handle) {
+        SDL_GameControllerClose(window->controller.handle);
+        window->controller.handle = NULL;
+        window->controller.is_connected = false;
+    }
+
     SDL_DestroyWindow(window->__sdl_window);
     SDL_Quit();
 
@@ -990,6 +1122,10 @@ void window_flush_transient_data(window_t *const self)
     self->mouse.rel = (vec2i_t){0};
     self->mouse.wheel.state = SDL_MOUSEWHEEL_NONE;
 
+    for (int i = 0; i < SDL_CONTROLLER_BUTTON_MAX; i++) {
+        self->controller.button_just_pressed[i] = false;
+        self->controller.button_released[i] = false;
+    }
 }
 
 

--- a/application/window/sdl_window.h
+++ b/application/window/sdl_window.h
@@ -90,14 +90,15 @@ typedef struct window_t {
         bool     is_held[SDL_NUM_SCANCODES];
     } keyboard;
 
+    //NOTE: tracks connected game controller state (buttons and analog axes)
     struct {
-        bool                is_connected;
-        SDL_GameController  *handle;
-        SDL_JoystickID      instance_id;
-        bool                button_just_pressed[SDL_CONTROLLER_BUTTON_MAX];
-        bool                button_is_held[SDL_CONTROLLER_BUTTON_MAX];
-        bool                button_released[SDL_CONTROLLER_BUTTON_MAX];
-        i16                 axis[SDL_CONTROLLER_AXIS_MAX];
+        bool                is_connected;                                   // whether a controller is currently connected
+        SDL_GameController  *handle;                                        // SDL game controller handle
+        SDL_JoystickID      instance_id;                                    // unique id for hotplug detection
+        bool                button_just_pressed[SDL_CONTROLLER_BUTTON_MAX]; // set on press, cleared after one frame
+        bool                button_is_held[SDL_CONTROLLER_BUTTON_MAX];      // set while button is held down
+        bool                button_released[SDL_CONTROLLER_BUTTON_MAX];     // set on release, cleared after one frame
+        i16                 axis[SDL_CONTROLLER_AXIS_MAX];                  // raw axis values (-32768 to 32767)
     } controller;
 
     struct {
@@ -267,32 +268,38 @@ bool window_mouse_wheel_is_scroll_left(const window_t *const w)
     return w->mouse.wheel.state == SDL_MOUSEWHEEL_LEFT;
 }
 
+// returns true if a game controller is currently connected
 bool window_controller_is_connected(window_t *window)
 {
     return window->controller.is_connected;
 }
 
+// returns true only on the frame the button was first pressed
 bool window_controller_button_just_pressed(window_t *window, SDL_GameControllerButton button)
 {
     return window->controller.button_just_pressed[button];
 }
 
+// returns true while a button is held down (after the first frame)
 bool window_controller_button_is_held(window_t *window, SDL_GameControllerButton button)
 {
     return window->controller.button_is_held[button];
 }
 
+// returns true if the button is either just pressed or held
 bool window_controller_button_is_pressed(window_t *window, SDL_GameControllerButton button)
 {
     return window->controller.button_just_pressed[button]
         || window->controller.button_is_held[button];
 }
 
+// returns the raw analog axis value (-32768 to 32767)
 i16 window_controller_get_axis_value(window_t *window, SDL_GameControllerAxis axis)
 {
     return window->controller.axis[axis];
 }
 
+// tracks controller button state machine: JUST_PRESSED -> HELD -> RELEASED
 INTERNAL void __controller_handle_button(window_t *window, SDL_GameControllerButton button, bool down)
 {
     if (down) {
@@ -486,8 +493,10 @@ window_t * window_init(const char *title, u64 width, u64 height, const u32 flags
     WinFlags = SDL_WINDOW_OPENGL;
 #endif
 
+    //NOTE: SDL_INIT_EVERYTHING includes game controller subsystem
     if (SDL_Init(flags) == -1) eprint("SDL Error: %s\n", SDL_GetError());
 
+    //NOTE: try to open the first available game controller at startup
     {
         int num_joysticks = SDL_NumJoysticks();
         if (num_joysticks > 0) {
@@ -958,11 +967,13 @@ void window_poll_input_events(window_t *window)
                 __keyboard_update_buffers(window, SDL_KEYUP, event->key.keysym.scancode);
             break;
 
+            //NOTE: a new controller was plugged in
             case SDL_CONTROLLERDEVICEADDED:
             {
                 SDL_GameController *ctrl = SDL_GameControllerOpen(event->cdevice.which);
                 if (ctrl) {
                     if (window->controller.is_connected) {
+                        // already have one, ignore extras
                         SDL_GameControllerClose(ctrl);
                     } else {
                         window->controller.handle = ctrl;
@@ -974,6 +985,7 @@ void window_poll_input_events(window_t *window)
                 }
             } break;
 
+            //NOTE: a controller was unplugged
             case SDL_CONTROLLERDEVICEREMOVED:
             {
                 if (window->controller.is_connected &&
@@ -988,6 +1000,7 @@ void window_poll_input_events(window_t *window)
                 }
             } break;
 
+            //NOTE: a controller button was pressed (transition to JUST_PRESSED or HELD)
             case SDL_CONTROLLERBUTTONDOWN:
             {
                 if (window->controller.is_connected) {
@@ -995,6 +1008,7 @@ void window_poll_input_events(window_t *window)
                 }
             } break;
 
+            //NOTE: a controller button was released (transition to RELEASED state)
             case SDL_CONTROLLERBUTTONUP:
             {
                 if (window->controller.is_connected) {
@@ -1002,6 +1016,7 @@ void window_poll_input_events(window_t *window)
                 }
             } break;
 
+            //NOTE: an analog axis moved (left stick, right stick, triggers)
             case SDL_CONTROLLERAXISMOTION:
             {
                 if (window->controller.is_connected) {
@@ -1100,6 +1115,7 @@ void window_destroy(void)
         window->subwindow.is_active = false;
     }
 
+    //NOTE: close game controller before quitting SDL
     if (window->controller.is_connected && window->controller.handle) {
         SDL_GameControllerClose(window->controller.handle);
         window->controller.handle = NULL;
@@ -1122,6 +1138,7 @@ void window_flush_transient_data(window_t *const self)
     self->mouse.rel = (vec2i_t){0};
     self->mouse.wheel.state = SDL_MOUSEWHEEL_NONE;
 
+    //NOTE: clear one-shot controller button states so they don't persist across frames
     for (int i = 0; i < SDL_CONTROLLER_BUTTON_MAX; i++) {
         self->controller.button_just_pressed[i] = false;
         self->controller.button_released[i] = false;

--- a/input/commandqueue.h
+++ b/input/commandqueue.h
@@ -94,7 +94,6 @@ void commandqueue_sync(commandqueue_t * const self)
             bool triggered = false;
 
             //NOTE: if deadzone is set, treat as axis-as-button binding
-            //      example: left stick pushed past 8000 units triggers walk forward
             if (b->sdl_controller.axis_as_button.deadzone != 0 && window_controller_is_connected(global_window)) {
                 i16 val = window_controller_get_axis_value(global_window, b->sdl_controller.axis_as_button.axis);
                 triggered = b->sdl_controller.axis_as_button.positive
@@ -102,14 +101,34 @@ void commandqueue_sync(commandqueue_t * const self)
                     : val < -b->sdl_controller.axis_as_button.deadzone;
             }
 
-            //NOTE: fall back to regular button check if axis didn't trigger (deadzone == 0)
+            //NOTE: fall back to regular button check if axis didn't trigger
             if (!triggered && window_controller_is_connected(global_window)) {
                 triggered = window_controller_button_is_pressed(global_window, b->sdl_controller.button);
             }
 
             if (triggered) {
                 self->internal.bitmask |= (1 << b->command);
-                //printf("CTRL Tracked %i\n", b->command);
+            }
+
+        //NOTE: keyboard AND controller OR'd together in a single binding
+        } else if (b->type == COMMANDINPUTKEY_TYPE_KEYBOARD_AND_CONTROLLER) {
+
+            bool triggered = keyboard_buffer[b->sdl_keyboard_and_controller.scancode];
+
+            if (!triggered && window_controller_is_connected(global_window)) {
+
+                if (b->sdl_keyboard_and_controller.axis_as_button.deadzone != 0) {
+                    i16 val = window_controller_get_axis_value(global_window, b->sdl_keyboard_and_controller.axis_as_button.axis);
+                    triggered = b->sdl_keyboard_and_controller.axis_as_button.positive
+                        ? val > b->sdl_keyboard_and_controller.axis_as_button.deadzone
+                        : val < -b->sdl_keyboard_and_controller.axis_as_button.deadzone;
+                } else {
+                    triggered = window_controller_button_is_pressed(global_window, b->sdl_keyboard_and_controller.button);
+                }
+            }
+
+            if (triggered) {
+                self->internal.bitmask |= (1 << b->command);
             }
         }
         //printf("Bitmask: ");cq__internal_print_u16_bitmask(self->internal.bitmask);

--- a/input/commandqueue.h
+++ b/input/commandqueue.h
@@ -88,10 +88,13 @@ void commandqueue_sync(commandqueue_t * const self)
 
             //printf("MS Tracked %i\n", b->command);
 
+        //NOTE: controller input (button or axis-as-button with deadzone)
         } else if (b->type == COMMANDINPUTKEY_TYPE_CONTROLLER) {
 
             bool triggered = false;
 
+            //NOTE: if deadzone is set, treat as axis-as-button binding
+            //      example: left stick pushed past 8000 units triggers walk forward
             if (b->sdl_controller.axis_as_button.deadzone != 0 && window_controller_is_connected(global_window)) {
                 i16 val = window_controller_get_axis_value(global_window, b->sdl_controller.axis_as_button.axis);
                 triggered = b->sdl_controller.axis_as_button.positive
@@ -99,6 +102,7 @@ void commandqueue_sync(commandqueue_t * const self)
                     : val < -b->sdl_controller.axis_as_button.deadzone;
             }
 
+            //NOTE: fall back to regular button check if axis didn't trigger (deadzone == 0)
             if (!triggered && window_controller_is_connected(global_window)) {
                 triggered = window_controller_button_is_pressed(global_window, b->sdl_controller.button);
             }

--- a/input/commandqueue.h
+++ b/input/commandqueue.h
@@ -63,28 +63,50 @@ void commandqueue_sync(commandqueue_t * const self)
     const commandregistry_t *commands = &self->registry;
 
     //printf("-------------------- NEW BATCH --------------------------------\n");
-    for (u16 command_type = 0; command_type < commands->count; command_type++) {
+    for (u16 i = 0; i < commands->count; i++) {
 
-        if (self->registry.registry[command_type].type == COMMANDINPUTKEY_TYPE_KEYBOARD && keyboard_buffer[self->registry.registry[command_type].sdl_keyboard_key.scancode]) {
+        const commandinputbinding_t *b = &self->registry.registry[i];
 
-            self->internal.bitmask |= (1 << command_type);
+        if (b->type == COMMANDINPUTKEY_TYPE_KEYBOARD && keyboard_buffer[b->sdl_keyboard_key.scancode]) {
 
-            //printf("KB Tracked %i\n", command_type);
+            self->internal.bitmask |= (1 << b->command);
 
-        } else if (self->registry.registry[command_type].type == COMMANDINPUTKEY_TYPE_MOUSE) {
+            //printf("KB Tracked %i\n", b->command);
 
-            const sdl_mousebuttontype key   = self->registry.registry[command_type].sdl_mouse.key;
-            const sdl_mousewheelstate wheel = self->registry.registry[command_type].sdl_mouse.wheel;
+        } else if (b->type == COMMANDINPUTKEY_TYPE_MOUSE) {
 
-            const bool found_match = (key != SDL_MOUSEBUTTON_NONE && commandqueue__internal_check_mousebutton_trigger(self->registry.registry[command_type]))
+            const sdl_mousebuttontype key   = b->sdl_mouse.key;
+            const sdl_mousewheelstate wheel = b->sdl_mouse.wheel;
+
+            const bool found_match = (key != SDL_MOUSEBUTTON_NONE && commandqueue__internal_check_mousebutton_trigger(self->registry.registry[i]))
                 || (wheel == SDL_MOUSEWHEEL_UP && window_mouse_wheel_is_scroll_up(global_window))
                 || (wheel == SDL_MOUSEWHEEL_DOWN && window_mouse_wheel_is_scroll_down(global_window));
 
             if (!found_match) continue;
 
-            self->internal.bitmask |= (1 << command_type);
+            self->internal.bitmask |= (1 << b->command);
 
-            //printf("MS Tracked %i\n", command_type);
+            //printf("MS Tracked %i\n", b->command);
+
+        } else if (b->type == COMMANDINPUTKEY_TYPE_CONTROLLER) {
+
+            bool triggered = false;
+
+            if (b->sdl_controller.axis_as_button.deadzone != 0 && window_controller_is_connected(global_window)) {
+                i16 val = window_controller_get_axis_value(global_window, b->sdl_controller.axis_as_button.axis);
+                triggered = b->sdl_controller.axis_as_button.positive
+                    ? val > b->sdl_controller.axis_as_button.deadzone
+                    : val < -b->sdl_controller.axis_as_button.deadzone;
+            }
+
+            if (!triggered && window_controller_is_connected(global_window)) {
+                triggered = window_controller_button_is_pressed(global_window, b->sdl_controller.button);
+            }
+
+            if (triggered) {
+                self->internal.bitmask |= (1 << b->command);
+                //printf("CTRL Tracked %i\n", b->command);
+            }
         }
         //printf("Bitmask: ");cq__internal_print_u16_bitmask(self->internal.bitmask);
     }

--- a/input/commandregistry.h
+++ b/input/commandregistry.h
@@ -4,18 +4,16 @@
 #include <poglib/application/window/sdl_window.h>
 
 
-//INFO:  this requires command actions to be enums as those are the 
-//index that maps to the specific sdl provided input state (command key)
-//
-//
 typedef enum {
   COMMANDINPUTKEY_TYPE_KEYBOARD = 0,
   COMMANDINPUTKEY_TYPE_MOUSE = 1,
+  COMMANDINPUTKEY_TYPE_CONTROLLER = 2,
   COMMANDINPUTKEY_TYPE_COUNT
 } commandinputkey_type;
 
 typedef struct {
     commandinputkey_type type;
+    u16                 command;
     union {
         struct {
             SDL_Scancode scancode;
@@ -25,6 +23,14 @@ typedef struct {
             sdl_mousewheelstate wheel;
             sdl_mousestate      trigger;
         } sdl_mouse;
+        struct {
+            SDL_GameControllerButton button;
+            struct {
+                SDL_GameControllerAxis axis;
+                i16 deadzone;
+                bool positive;
+            } axis_as_button;
+        } sdl_controller;
     };
 } commandinputbinding_t;
 

--- a/input/commandregistry.h
+++ b/input/commandregistry.h
@@ -4,16 +4,18 @@
 #include <poglib/application/window/sdl_window.h>
 
 
+//INFO:  each registry entry maps to a command bit (via .command field).
+//       The type selects which input source(s) to check:
+//       KEYBOARD/MOUSE/CONTROLLER for single source,
+//       KEYBOARD_AND_CONTROLLER for OR-ing keyboard + controller inputs.
 typedef enum {
   COMMANDINPUTKEY_TYPE_KEYBOARD = 0,
   COMMANDINPUTKEY_TYPE_MOUSE = 1,
-  COMMANDINPUTKEY_TYPE_CONTROLLER = 2,    // gamepad button or axis-as-button
+  COMMANDINPUTKEY_TYPE_CONTROLLER = 2,              // gamepad button or axis-as-button
+  COMMANDINPUTKEY_TYPE_KEYBOARD_AND_CONTROLLER = 3, // keyboard OR controller triggers the command
   COMMANDINPUTKEY_TYPE_COUNT
 } commandinputkey_type;
 
-//NOTE: each binding maps an input source to a command bit
-//      .command explicitly sets which bit to toggle in the bitmask (decoupled from array index)
-//      this allows OR bindings (e.g., keyboard + controller for the same command)
 typedef struct {
     commandinputkey_type type;
     u16                 command;            // which command bit to set when triggered
@@ -34,6 +36,15 @@ typedef struct {
                 bool positive;                  // true = positive direction, false = negative direction
             } axis_as_button;                   // treats analog stick/trigger as a digital button
         } sdl_controller;
+        struct {
+            SDL_Scancode scancode;              // keyboard key
+            SDL_GameControllerButton button;    // controller button (checked when deadzone == 0)
+            struct {
+                SDL_GameControllerAxis axis;
+                i16 deadzone;
+                bool positive;
+            } axis_as_button;                   // controller axis (checked when deadzone > 0)
+        } sdl_keyboard_and_controller;          // checked for BOTH keyboard AND controller
     };
 } commandinputbinding_t;
 

--- a/input/commandregistry.h
+++ b/input/commandregistry.h
@@ -7,13 +7,16 @@
 typedef enum {
   COMMANDINPUTKEY_TYPE_KEYBOARD = 0,
   COMMANDINPUTKEY_TYPE_MOUSE = 1,
-  COMMANDINPUTKEY_TYPE_CONTROLLER = 2,
+  COMMANDINPUTKEY_TYPE_CONTROLLER = 2,    // gamepad button or axis-as-button
   COMMANDINPUTKEY_TYPE_COUNT
 } commandinputkey_type;
 
+//NOTE: each binding maps an input source to a command bit
+//      .command explicitly sets which bit to toggle in the bitmask (decoupled from array index)
+//      this allows OR bindings (e.g., keyboard + controller for the same command)
 typedef struct {
     commandinputkey_type type;
-    u16                 command;
+    u16                 command;            // which command bit to set when triggered
     union {
         struct {
             SDL_Scancode scancode;
@@ -24,12 +27,12 @@ typedef struct {
             sdl_mousestate      trigger;
         } sdl_mouse;
         struct {
-            SDL_GameControllerButton button;
+            SDL_GameControllerButton button;    // checked when axis_as_button.deadzone == 0
             struct {
                 SDL_GameControllerAxis axis;
-                i16 deadzone;
-                bool positive;
-            } axis_as_button;
+                i16 deadzone;                   // minimum axis value to trigger (>0 enables axis mode)
+                bool positive;                  // true = positive direction, false = negative direction
+            } axis_as_button;                   // treats analog stick/trigger as a digital button
         } sdl_controller;
     };
 } commandinputbinding_t;


### PR DESCRIPTION
Adds game controller support to the SDL2 platform layer and command queue.

### Changes in sdl_window.h
- SDL_GameController state tracking (buttons, axes, connection state) in window_t
- SDL_CONTROLLERDEVICEADDED/REMOVED/BUTTON/AXIS event handling
- Controller init on startup and cleanup on shutdown
- Helper functions for button state queries and axis value queries

### Changes in commandregistry.h
- Added COMMANDINPUTKEY_TYPE_CONTROLLER enum value
- Added sdl_controller union member with button and axis-as-button bindings
- Added .command field to decouple array index from bit position (enables OR bindings)

### Changes in commandqueue.h
- commandqueue_sync() now checks controller bindings (buttons and axis thresholds with deadzone)
- Uses .command field instead of array index for bitmask position