### PR TITLE
fix: replace mtx_t with atomic_flag spinlock in arena to avoid glibc TPP crash

### DIFF
--- a/basic/arena.h
+++ b/basic/arena.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "dbg.h"
 #include "common.h"
-#include "threads.h"
+#include <stdatomic.h>
+#include <threads.h>
 #include <stdint.h>
 
 /*================================================================================
@@ -26,7 +27,7 @@ struct arena_t {
         u32 count;
     } freelist;
     struct {
-        mtx_t lock;
+        atomic_flag lock;
         struct arena_t *lifetime_owner;
     } meta;
 };
@@ -55,7 +56,7 @@ arena_t arena_init(arena_t *arena, u64 capacity)
             .lifetime_owner = arena,
         }
     };
-    mtx_init(&o.meta.lock, mtx_plain);
+    atomic_flag_clear(&o.meta.lock);
     return o;
 }
 
@@ -99,7 +100,7 @@ void * arena__internal_reserve_memory_16byte_aligned(arena_t * const self, const
     const u64 align = 16;
     void *mem = NULL;
 
-    mtx_lock(&self->meta.lock);
+    while (atomic_flag_test_and_set(&self->meta.lock)) { thrd_yield(); }
     {
         const u64 current_ptr = (u64)self->memory + self->size;
         const u64 aligned_ptr = (current_ptr + (align - 1)) & ~(align - 1);
@@ -109,14 +110,14 @@ void * arena__internal_reserve_memory_16byte_aligned(arena_t * const self, const
         if ((offset + memory_size) > self->capacity)
         {
             eprint("Arena is full");
-            mtx_unlock(&self->meta.lock);
+            atomic_flag_clear(&self->meta.lock);
             return NULL;
         }
 
         void *res_memory = arena__internal_check_in_freelist(self, memory_size);
         if (res_memory) {
             memset(res_memory, 0, memory_size);
-            mtx_unlock(&self->meta.lock);
+            atomic_flag_clear(&self->meta.lock);
             return res_memory;
         }
 
@@ -125,7 +126,7 @@ void * arena__internal_reserve_memory_16byte_aligned(arena_t * const self, const
 
         self->size = offset + memory_size;
     }
-    mtx_unlock(&self->meta.lock);
+    atomic_flag_clear(&self->meta.lock);
 
     ASSERT(mem);
     if(((u64)(mem) & (16 - 1)) != 0) {
@@ -136,9 +137,9 @@ void * arena__internal_reserve_memory_16byte_aligned(arena_t * const self, const
 
 void arena_clear(arena_t *self)
 {
-    mtx_lock(&self->meta.lock);
+    while (atomic_flag_test_and_set(&self->meta.lock)) { thrd_yield(); }
         self->size = 0;
-    mtx_unlock(&self->meta.lock);
+    atomic_flag_clear(&self->meta.lock);
 }
 
 
@@ -149,7 +150,7 @@ void arena_giveback(arena_t *self, const void *ptr, const u64 size)
     ASSERT(size > 0);
     ASSERT(arena_is_init(self));
 
-    mtx_lock(&self->meta.lock);
+    while (atomic_flag_test_and_set(&self->meta.lock)) { thrd_yield(); }
     {
         free_chunks_t *chunk = self->freelist.head;
         while(chunk != NULL && chunk->next != NULL) {
@@ -174,18 +175,17 @@ void arena_giveback(arena_t *self, const void *ptr, const u64 size)
         }
         self->freelist.count++;
     }
-    mtx_unlock(&self->meta.lock);
+    atomic_flag_clear(&self->meta.lock);
 }
 
 void arena_destroy(arena_t *self)
 {
     if (self->meta.lifetime_owner) {
         arena_giveback(self->meta.lifetime_owner, self->memory, self->capacity);
-        mtx_destroy(&self->meta.lock);
         return;
     }
 
-    mtx_lock(&self->meta.lock); 
+    while (atomic_flag_test_and_set(&self->meta.lock)) { thrd_yield(); }
     {
         if (self->freelist.count) {
             free_chunks_t *cur = self->freelist.head;
@@ -198,9 +198,7 @@ void arena_destroy(arena_t *self)
             free(self->memory);
         }
     }
-    mtx_unlock(&self->meta.lock);
-
-    mtx_destroy(&self->meta.lock);
+    atomic_flag_clear(&self->meta.lock);
 }
 
 void * arena_reserve(arena_t *self, u64 memory_size)

--- a/test/arena/main.c
+++ b/test/arena/main.c
@@ -1,73 +1,373 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <threads.h>
 #include <assert.h>
-#include "../../basic/arena.h"  // Your arena header
+#include <string.h>
+#include <threads.h>
+#include "../../basic/arena.h"
 
-#define ARENA_CAPACITY 1024
+#define ARENA_CAPACITY 4096
+#define TEST_PATTERN_1 0xAB
+#define TEST_PATTERN_2 0xCD
 
-// Simple test: Reserve memory and give it back, then re-reserve same size should reuse
-void test_single_thread_basic() {
+/* ── Single-threaded tests ───────────────────────────────────────────── */
+
+static void test_init_null(void) {
     arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    assert(arena.memory != NULL);
+    assert(arena.capacity == ARENA_CAPACITY);
+    assert(arena.size == 0);
+    assert(arena.meta.lifetime_owner == NULL);
+    arena_destroy(&arena);
+    printf("PASS: test_init_null\n");
+}
 
+static void test_init_sub_arena(void) {
+    arena_t parent = arena_init(NULL, ARENA_CAPACITY);
+    arena_t sub = arena_init(&parent, 256);
+    assert(sub.memory != NULL);
+    assert(sub.capacity == 256);
+    assert(sub.meta.lifetime_owner == &parent);
+    assert((u8 *)sub.memory >= parent.memory);
+    assert((u8 *)sub.memory + 256 <= parent.memory + parent.capacity);
+    arena_destroy(&sub);
+    arena_destroy(&parent);
+    printf("PASS: test_init_sub_arena\n");
+}
+
+static void test_reserve_basic(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    void *p1 = arena_reserve(&arena, 64);
+    void *p2 = arena_reserve(&arena, 64);
+    assert(p1 != NULL);
+    assert(p2 != NULL);
+    assert(p1 != p2);
+    assert((u8 *)p2 >= (u8 *)p1 + 64);
+    arena_destroy(&arena);
+    printf("PASS: test_reserve_basic\n");
+}
+
+static void test_reserve_alignment(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    for (int i = 0; i < 20; i++) {
+        void *p = arena_reserve(&arena, 1 + (i % 7));
+        assert(p != NULL);
+        assert(((u64)p & 0xF) == 0);
+    }
+    arena_destroy(&arena);
+    printf("PASS: test_reserve_alignment\n");
+}
+
+static void test_giveback_reuse(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
     void *p1 = arena_reserve(&arena, 100);
     assert(p1 != NULL);
-
     arena_giveback(&arena, p1, 100);
-
     void *p2 = arena_reserve(&arena, 100);
-    assert(p2 == p1);  // Should reuse same chunk from freelist
-
+    assert(p2 == p1);
     arena_destroy(&arena);
-    printf("test_single_thread_basic passed\n");
+    printf("PASS: test_giveback_reuse\n");
 }
 
-// Test that arena_clear resets size and subsequent allocations start fresh
-void test_clear() {
+static void test_store(void) {
     arena_t arena = arena_init(NULL, ARENA_CAPACITY);
-
-    void *p1 = arena_reserve(&arena, 50);
-    arena_clear(&arena);
-
-    void *p2 = arena_reserve(&arena, 50);
-    assert(p2 == arena.memory); // After clear, allocations start from beginning
-
+    const char test_str[] = "Hello, Arena!";
+    size_t len = strlen(test_str) + 1;
+    char *stored = (char *)arena_store(&arena, test_str, len);
+    assert(stored != NULL);
+    assert(stored != test_str);
+    assert(memcmp(stored, test_str, len) == 0);
     arena_destroy(&arena);
-    printf("test_clear passed\n");
+    printf("PASS: test_store\n");
 }
 
-// Multithreaded test: multiple threads allocating and giving back concurrently
-int thread_func(void *arg) {
-    arena_t *arena = (arena_t *)arg;
-    for (int i = 0; i < 100; i++) {
-        void *p = arena_reserve(arena, 10);
-        thrd_yield(); // Yield to increase contention chances
-        arena_giveback(arena, p, 10);
+static void test_clear(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    arena_reserve(&arena, 50);
+    arena_clear(&arena);
+    void *p2 = arena_reserve(&arena, 50);
+    assert(p2 == arena.memory);
+    arena_destroy(&arena);
+    printf("PASS: test_clear\n");
+}
+
+static void test_is_init(void) {
+    arena_t zeroed = {0};
+    assert(arena_is_init(&zeroed) == false);
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    assert(arena_is_init(&arena) == true);
+    arena_destroy(&arena);
+    printf("PASS: test_is_init\n");
+}
+
+static void test_destroy_top_level_only(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    arena_destroy(&arena);
+    printf("PASS: test_destroy_top_level_only\n");
+}
+
+static void test_destroy_sub_arena(void) {
+    arena_t parent = arena_init(NULL, ARENA_CAPACITY);
+    for (int i = 0; i < 5; i++) {
+        arena_t sub = arena_init(&parent, 64);
+        void *p = arena_reserve(&sub, 16);
+        assert(p != NULL);
+        arena_destroy(&sub);
     }
+    arena_destroy(&parent);
+    printf("PASS: test_destroy_sub_arena\n");
+}
+
+static void test_many_small_alloc(void) {
+    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
+    enum { COUNT = 50 };
+    void *ptrs[COUNT];
+    int sizes[COUNT];
+
+    for (int i = 0; i < COUNT; i++) {
+        sizes[i] = 4 + (i % 8) * 4;
+        ptrs[i] = arena_reserve(&arena, sizes[i]);
+        assert(ptrs[i] != NULL);
+        memset(ptrs[i], TEST_PATTERN_1, sizes[i]);
+    }
+    for (int i = 0; i < COUNT; i++) {
+        u8 *data = (u8 *)ptrs[i];
+        for (int j = 0; j < sizes[i]; j++)
+            assert(data[j] == TEST_PATTERN_1);
+    }
+    for (int i = 0; i < COUNT; i += 2)
+        arena_giveback(&arena, ptrs[i], sizes[i]);
+    for (int i = 0; i < COUNT; i += 2) {
+        void *re = arena_reserve(&arena, sizes[i]);
+        assert(re != NULL);
+        memset(re, TEST_PATTERN_2, sizes[i]);
+    }
+    arena_destroy(&arena);
+    printf("PASS: test_many_small_alloc\n");
+}
+
+/* ── Multi-threaded helpers ──────────────────────────────────────────── */
+
+typedef struct {
+    arena_t *arena;
+    int thread_id;
+    int num_ops;
+    bool success;
+} mt_worker_t;
+
+static int mt_reserve_worker(void *arg) {
+    mt_worker_t *w = (mt_worker_t *)arg;
+    for (int i = 0; i < w->num_ops; i++) {
+        void *p = arena_reserve(w->arena, 16);
+        if (!p) { w->success = false; return 1; }
+        u32 pattern = ((u32)w->thread_id << 16) | (u32)i;
+        memcpy(p, &pattern, sizeof(pattern));
+        thrd_yield();
+    }
+    w->success = true;
     return 0;
 }
 
-void test_multithreaded() {
-    arena_t arena = arena_init(NULL, ARENA_CAPACITY);
-
+static void test_mt_parallel_reserve(void) {
+    arena_t arena = arena_init(NULL, 4096);
     thrd_t threads[4];
+    mt_worker_t workers[4];
+
     for (int i = 0; i < 4; i++) {
-        thrd_create(&threads[i], thread_func, &arena);
+        workers[i] = (mt_worker_t){
+            .arena = &arena,
+            .thread_id = i,
+            .num_ops = 20,
+        };
+        thrd_create(&threads[i], mt_reserve_worker, &workers[i]);
     }
     for (int i = 0; i < 4; i++) {
         thrd_join(threads[i], NULL);
+        assert(workers[i].success);
     }
-
     arena_destroy(&arena);
-    printf("test_multithreaded passed\n");
+    printf("PASS: test_mt_parallel_reserve\n");
 }
 
-int main() {
-    test_single_thread_basic();
-    test_clear();
-    test_multithreaded();
+typedef struct {
+    arena_t *arena;
+    void **ptrs;
+    int count;
+    bool success;
+} mt_giveback_worker_t;
 
-    printf("All tests passed!\n");
+static int mt_giveback_worker(void *arg) {
+    mt_giveback_worker_t *w = (mt_giveback_worker_t *)arg;
+    for (int i = 0; i < w->count; i++) {
+        if (w->ptrs[i]) {
+            arena_giveback(w->arena, w->ptrs[i], 16);
+            w->ptrs[i] = NULL;
+        }
+        thrd_yield();
+    }
+    w->success = true;
     return 0;
 }
 
+static void test_mt_parallel_giveback(void) {
+    arena_t arena = arena_init(NULL, 2048);
+    enum { N = 4, OPS = 10 };
+    void *all_ptrs[N * OPS];
+
+    for (int i = 0; i < N * OPS; i++) {
+        all_ptrs[i] = arena_reserve(&arena, 16);
+        assert(all_ptrs[i] != NULL);
+    }
+
+    thrd_t threads[N];
+    mt_giveback_worker_t workers[N];
+
+    for (int i = 0; i < N; i++) {
+        workers[i] = (mt_giveback_worker_t){
+            .arena = &arena,
+            .ptrs = &all_ptrs[i * OPS],
+            .count = OPS,
+        };
+        thrd_create(&threads[i], mt_giveback_worker, &workers[i]);
+    }
+    for (int i = 0; i < N; i++) {
+        thrd_join(threads[i], NULL);
+        assert(workers[i].success);
+    }
+    arena_destroy(&arena);
+    printf("PASS: test_mt_parallel_giveback\n");
+}
+
+static int mt_mixed_worker(void *arg) {
+    mt_worker_t *w = (mt_worker_t *)arg;
+    for (int i = 0; i < w->num_ops; i++) {
+        void *p = arena_reserve(w->arena, 8);
+        if (p) {
+            thrd_yield();
+            arena_giveback(w->arena, p, 8);
+        }
+    }
+    w->success = true;
+    return 0;
+}
+
+static void test_mt_mixed_stress(void) {
+    arena_t arena = arena_init(NULL, 4096);
+    thrd_t threads[8];
+    mt_worker_t workers[8];
+
+    for (int i = 0; i < 8; i++) {
+        workers[i] = (mt_worker_t){
+            .arena = &arena,
+            .thread_id = i,
+            .num_ops = 100,
+        };
+        thrd_create(&threads[i], mt_mixed_worker, &workers[i]);
+    }
+    for (int i = 0; i < 8; i++) {
+        thrd_join(threads[i], NULL);
+        assert(workers[i].success);
+    }
+    arena_destroy(&arena);
+    printf("PASS: test_mt_mixed_stress\n");
+}
+
+typedef struct {
+    arena_t *parent;
+    bool success;
+} mt_sub_arena_worker_t;
+
+static int mt_sub_arena_worker(void *arg) {
+    mt_sub_arena_worker_t *w = (mt_sub_arena_worker_t *)arg;
+    arena_t sub = arena_init(w->parent, 128);
+    if (!arena_is_init(&sub)) {
+        w->success = false; return 1;
+    }
+    void *p = arena_reserve(&sub, 32);
+    if (!p) {
+        w->success = false; return 1;
+    }
+    thrd_yield();
+    arena_destroy(&sub);
+    w->success = true;
+    return 0;
+}
+
+static void test_mt_sub_arenas(void) {
+    arena_t parent = arena_init(NULL, ARENA_CAPACITY);
+    thrd_t threads[4];
+    mt_sub_arena_worker_t workers[4];
+
+    for (int i = 0; i < 4; i++) {
+        workers[i] = (mt_sub_arena_worker_t){
+            .parent = &parent,
+        };
+        thrd_create(&threads[i], mt_sub_arena_worker, &workers[i]);
+    }
+    for (int i = 0; i < 4; i++) {
+        thrd_join(threads[i], NULL);
+        assert(workers[i].success);
+    }
+    arena_destroy(&parent);
+    printf("PASS: test_mt_sub_arenas\n");
+}
+
+static int mt_store_worker(void *arg) {
+    mt_worker_t *w = (mt_worker_t *)arg;
+    for (int i = 0; i < w->num_ops; i++) {
+        u64 data = ((u64)w->thread_id << 32) | (u64)i;
+        u64 *stored = (u64 *)arena_store(w->arena, &data, sizeof(data));
+        if (!stored) { w->success = false; return 1; }
+        assert(*stored == data);
+        thrd_yield();
+    }
+    w->success = true;
+    return 0;
+}
+
+static void test_mt_arena_store(void) {
+    arena_t arena = arena_init(NULL, 4096);
+    thrd_t threads[4];
+    mt_worker_t workers[4];
+
+    for (int i = 0; i < 4; i++) {
+        workers[i] = (mt_worker_t){
+            .arena = &arena,
+            .thread_id = i,
+            .num_ops = 20,
+        };
+        thrd_create(&threads[i], mt_store_worker, &workers[i]);
+    }
+    for (int i = 0; i < 4; i++) {
+        thrd_join(threads[i], NULL);
+        assert(workers[i].success);
+    }
+    arena_destroy(&arena);
+    printf("PASS: test_mt_arena_store\n");
+}
+
+/* ── Main ───────────────────────────────────────────────────────────── */
+
+int main(void) {
+    /* Single-threaded */
+    test_init_null();
+    test_init_sub_arena();
+    test_reserve_basic();
+    test_reserve_alignment();
+    test_giveback_reuse();
+    test_store();
+    test_clear();
+    test_is_init();
+    test_destroy_top_level_only();
+    test_destroy_sub_arena();
+    test_many_small_alloc();
+
+    /* Multi-threaded */
+    test_mt_parallel_reserve();
+    test_mt_parallel_giveback();
+    test_mt_mixed_stress();
+    test_mt_sub_arenas();
+    test_mt_arena_store();
+
+    printf("\nAll arena tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Problem

After merging arena-threading PRs (#10, #13), glmodel_init in a background worker thread triggers `__pthread_tpp_change_priority` assertion on glibc 2.43. This happens because `arena.h` uses C11 `mtx_t` mutexes, which under glibc go through pthread priority protection protocol code. After SDL3 initializes its priority state in `SDL_Init`, any subsequent `mtx_lock` in a background thread hits this assertion.

## Fix

Replace `mtx_t` with a lightweight `atomic_flag` spinlock in `basic/arena.h`. The arena's critical sections are extremely short (pointer arithmetic and freelist management), making a spinlock a natural fit. This completely avoids glibc's pthread mutex machinery and the TPP code path.

### Changes
- **basic/arena.h**: Replaced `mtx_t` lock → `atomic_flag` lock, all `mtx_init/mtx_lock/mtx_unlock/mtx_destroy` → `atomic_flag_clear/atomic_flag_test_and_set + thrd_yield`
- **test/arena/main.c**: Comprehensive test cases covering all API functions in single-threaded and multi-threaded scenarios (16 tests total)

### Verification
- All 16 arena tests pass (single-threaded + multi-threaded)
- GetBack builds successfully against the updated code

Fixes the startup crash in GetBack caused by `__pthread_tpp_change_priority` assertion.