### PR TITLE
gui: fix bugs, add text alignment, rounded corners, fill sizing, cons…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+poglib
 *.obj
 *.pdb
 *.ilk

--- a/basic/common.h
+++ b/basic/common.h
@@ -25,7 +25,9 @@
 
 //NOTE: this should be truncated along the start of all file paths 
 //TODO: possible to inject string path here via the forge build script ?
+#ifndef POGLIB_ROOT_DIR
 #define POGLIB_ROOT_DIR     "lib/poglib"
+#endif
 
 typedef unsigned char   u8;
 typedef char            i8;

--- a/basic/dbg.h
+++ b/basic/dbg.h
@@ -1,6 +1,8 @@
 #pragma once
 #ifdef __linux__
+    #ifndef _GNU_SOURCE
     #define _GNU_SOURCE
+    #endif
     #include <dlfcn.h>
     #include <execinfo.h>
 #elif _WIN64

--- a/ecs/systems/model.h
+++ b/ecs/systems/model.h
@@ -12,6 +12,7 @@
 #include "poglib/util/asset.h"
 #include "poglib/util/assetmanager.h"
 #include "poglib/util/glcamera.h"
+#include "poglib/util/workbench/common.h"
 
 void ecs_system_render_model(ecs_componentmanager_t *const cmp_manager, const ecs_system_ctx_t ctx)
 {
@@ -114,7 +115,7 @@ void ecs_system_render_model(ecs_componentmanager_t *const cmp_manager, const ec
                                     },
                                     [5] = {
                                         .name = str_lit("light.color"),
-                                        .value.vec4 = COLOR_WHITE
+                                        .value.vec4 = global_workbench->editor.selected_entity_id == entry->entity_id ? COLOR_RED : COLOR_WHITE
                                     },
                                     [6] = {
                                         .name = str_lit("light.ambient"),

--- a/font/glfreetypefont.h
+++ b/font/glfreetypefont.h
@@ -19,7 +19,9 @@
 //quad, when passing the position
 
 #define MAX_CHARACTERS_IN_FREETYPE 128
+#ifndef DEFAULT_FONT_ROBOTO_MEDIUM_FILEPATH
 #define DEFAULT_FONT_ROBOTO_MEDIUM_FILEPATH "lib/poglib/res/ttf_fonts/Roboto-Medium.ttf"
+#endif
 
 typedef struct glfreetypefont_t {
 

--- a/gui.h
+++ b/gui.h
@@ -157,7 +157,6 @@ bool    gui_ui_isclicked(gui_t *const self, const u32 id);
 
 void    gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg);
 void    gui_label(gui_t *gui, str_t text, f32 w, f32 h, ui_config_t cfg);
-void    gui_panel(gui_t *gui, f32 w, f32 h, ui_config_t cfg);
 void    gui_render(gui_t *self);
 void    gui_destroy(gui_t *self);
 
@@ -421,6 +420,9 @@ void gui_ui_compose_begin(gui_t * const gui, const ui_config_t config)
         .is_text = false,
     };
     list_append(&gui->gfx.instanced_attrs, attr);
+
+    if (config.text.len > 0)
+        gui__internal_ui_create_text_internal(gui, child_region, config);
 }
 
 void gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg)
@@ -432,6 +434,7 @@ void gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg)
     cfg.dim.min_height = (u32)h;
     cfg.text = text;
     gui_ui_compose_begin(gui, cfg);
+    gui_ui_compose_end(gui);
 }
 
 void gui_label(gui_t *gui, str_t text, f32 w, f32 h, ui_config_t cfg)
@@ -442,13 +445,6 @@ void gui_label(gui_t *gui, str_t text, f32 w, f32 h, ui_config_t cfg)
     cfg.text = text;
     gui_ui_compose_begin(gui, cfg);
     gui_ui_compose_end(gui);
-}
-
-void gui_panel(gui_t *gui, f32 w, f32 h, ui_config_t cfg)
-{
-    cfg.dim.min_width  = (u32)w;
-    cfg.dim.min_height = (u32)h;
-    gui_ui_compose_begin(gui, cfg);
 }
 
 

--- a/gui.h
+++ b/gui.h
@@ -101,7 +101,7 @@ typedef struct {
     f32            is_text;
 } ui_attr_t;
 
-#define MAX_UI_NESTING_ALLOWED 4
+#define MAX_UI_NESTING_ALLOWED 16
 
 typedef struct gui_t gui_t;
 
@@ -168,13 +168,16 @@ bool    gui_ui_isclicked(gui_t *const self, const u32 id);
     })
 
 #define gui_label(GUI, TEXT, W, H, ...) \
-    gui_ui_compose_begin((GUI), (ui_config_t){ \
-        .composition = { .styles = UI_STYLE_ONLY_TEXT }, \
-        .dim = { .min_width = (W), .min_height = (H) }, \
-        .color = { .base = COLOR_WHITE }, \
-        .text = (TEXT), \
-        __VA_ARGS__ \
-    })
+    do { \
+        gui_ui_compose_begin((GUI), (ui_config_t){ \
+            .composition = { .styles = UI_STYLE_ONLY_TEXT }, \
+            .dim = { .min_width = (W), .min_height = (H) }, \
+            .color = { .base = COLOR_WHITE }, \
+            .text = (TEXT), \
+            __VA_ARGS__ \
+        }); \
+        gui_ui_compose_end((GUI)); \
+    } while(0)
 
 #define gui_panel(GUI, W, H, ...) \
     gui_ui_compose_begin((GUI), (ui_config_t){ \
@@ -311,7 +314,6 @@ ui_region_t gui__internal_ui_add_child(gui_t *gui, const ui_config_t config)
 
     if (config.size_mode == UI_SIZE_FILL) {
         child_width = parent_region.width - (f32)(config.margin.left + config.margin.right);
-        child_height = parent_layout.region.height - (f32)(config.margin.top + config.margin.bottom);
     }
 
     const f32 width_enclosed_by_child_region = (f32)config.margin.left + child_width + (f32)config.margin.right;
@@ -362,8 +364,12 @@ ui_region_t gui__internal_ui_add_child(gui_t *gui, const ui_config_t config)
                     .x = child_region.cursor.x + (f32)config.padding.left,
                     .y = child_region.cursor.y + (f32)config.padding.top
                 },
-                .height = child_region.height,
-                .width = child_region.width
+                .height = child_region.height - (f32)(config.padding.top + config.padding.bottom) > 0.0f
+                    ? child_region.height - (f32)(config.padding.top + config.padding.bottom)
+                    : 0.0f,
+                .width  = child_region.width  - (f32)(config.padding.left + config.padding.right) > 0.0f
+                    ? child_region.width  - (f32)(config.padding.left + config.padding.right)
+                    : 0.0f,
             },
             .max_row_height = (u32)child_region.height,
             .starting_region = child_region

--- a/gui.h
+++ b/gui.h
@@ -155,38 +155,9 @@ bool    gui_ui_isclicked(gui_t *const self, const u32 id);
     ((SELF)->callback((SELF), __VA_ARGS__));\
 } while(0);
 
-#define gui_button(GUI, ID, TEXT, W, H, ...) \
-    gui_ui_compose_begin((GUI), (ui_config_t){ \
-        .id = (ID), \
-        .composition = { \
-            .traits = UI_BEHAVIOR_HOVERABLE | UI_BEHAVIOR_CLICKABLE, \
-            .styles = UI_STYLE_ROUNDED_CORNERS, \
-        }, \
-        .dim = { .min_width = (W), .min_height = (H) }, \
-        .text = (TEXT), \
-        __VA_ARGS__ \
-    })
-
-#define gui_label(GUI, TEXT, W, H, ...) \
-    do { \
-        gui_ui_compose_begin((GUI), (ui_config_t){ \
-            .composition = { .styles = UI_STYLE_ONLY_TEXT }, \
-            .dim = { .min_width = (W), .min_height = (H) }, \
-            .color = { .base = COLOR_WHITE }, \
-            .text = (TEXT), \
-            __VA_ARGS__ \
-        }); \
-        gui_ui_compose_end((GUI)); \
-    } while(0)
-
-#define gui_panel(GUI, W, H, ...) \
-    gui_ui_compose_begin((GUI), (ui_config_t){ \
-        .dim = { .min_width = (W), .min_height = (H) }, \
-        .color = { .base = COLOR_BLACK }, \
-        __VA_ARGS__ \
-    })
-
-
+void    gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg);
+void    gui_label(gui_t *gui, str_t text, f32 w, f32 h, ui_config_t cfg);
+void    gui_panel(gui_t *gui, f32 w, f32 h, ui_config_t cfg);
 void    gui_render(gui_t *self);
 void    gui_destroy(gui_t *self);
 
@@ -450,6 +421,34 @@ void gui_ui_compose_begin(gui_t * const gui, const ui_config_t config)
         .is_text = false,
     };
     list_append(&gui->gfx.instanced_attrs, attr);
+}
+
+void gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg)
+{
+    cfg.id = id;
+    cfg.composition.traits = UI_BEHAVIOR_HOVERABLE | UI_BEHAVIOR_CLICKABLE;
+    cfg.composition.styles = UI_STYLE_ROUNDED_CORNERS;
+    cfg.dim.min_width  = (u32)w;
+    cfg.dim.min_height = (u32)h;
+    cfg.text = text;
+    gui_ui_compose_begin(gui, cfg);
+}
+
+void gui_label(gui_t *gui, str_t text, f32 w, f32 h, ui_config_t cfg)
+{
+    cfg.composition.styles = UI_STYLE_ONLY_TEXT;
+    cfg.dim.min_width  = (u32)w;
+    cfg.dim.min_height = (u32)h;
+    cfg.text = text;
+    gui_ui_compose_begin(gui, cfg);
+    gui_ui_compose_end(gui);
+}
+
+void gui_panel(gui_t *gui, f32 w, f32 h, ui_config_t cfg)
+{
+    cfg.dim.min_width  = (u32)w;
+    cfg.dim.min_height = (u32)h;
+    gui_ui_compose_begin(gui, cfg);
 }
 
 

--- a/gui.h
+++ b/gui.h
@@ -15,17 +15,15 @@
 #include <poglib/math.h>
 
 //INFO: This uses a stack based layout system -
-//Cursor starts from top left with (vec2ui_t){0}
+//Cursor starts from top left with (vec2f_t){0}
 //Each cursor update is pushed to the stack
 
 //TODO:
 //1.Scroll
-//2.Text wrapping 
-//3.Rounded corners
-//4.Way to have composition ui placed at the right end of the screen from the start
-//5.Way for enclosed text to take up the entire parent dimension instead
-//6.Toggle 
-//7.Text truncate
+//2.Text wrapping
+//3.Way to have composition ui placed at the right end of the screen from the start
+//4.Toggle
+//5.Text truncate
 
 //BUG:
 //1. WDC coordinates text are not wrapping around to next line of NDC coordinates text while enclosed in the same composition
@@ -42,6 +40,17 @@ typedef enum {
     UI_STYLE_ONLY_TEXT          = 1 << 1,
 } ui_style_config;
 
+typedef enum {
+    UI_TEXT_ALIGN_LEFT   = 0,
+    UI_TEXT_ALIGN_CENTER = 1,
+    UI_TEXT_ALIGN_RIGHT  = 2,
+} ui_text_align;
+
+typedef enum {
+    UI_SIZE_WRAP = 0,
+    UI_SIZE_FILL = 1,
+} ui_size_mode;
+
 typedef struct {
     vec2f_t cursor;
     f32 width;
@@ -56,11 +65,13 @@ typedef struct {
     } composition;
 
     struct {
-        u32 left;
+        u32 top;
         u32 right;
         u32 bottom;
-        u32 top;
-    } padding, margin, border, corners;
+        u32 left;
+    } padding, margin, border;
+
+    u32 corner_radius;
 
     struct {
         u32 min_width;
@@ -69,6 +80,8 @@ typedef struct {
 
     u32 id;
     str_t text;
+    u32 text_align;
+    u32 size_mode;
 
     struct {
         vec4f_t base;
@@ -142,6 +155,34 @@ bool    gui_ui_isclicked(gui_t *const self, const u32 id);
     ((SELF)->callback((SELF), __VA_ARGS__));\
 } while(0);
 
+#define gui_button(GUI, ID, TEXT, W, H, ...) \
+    gui_ui_compose_begin((GUI), (ui_config_t){ \
+        .id = (ID), \
+        .composition = { \
+            .traits = UI_BEHAVIOR_HOVERABLE | UI_BEHAVIOR_CLICKABLE, \
+            .styles = UI_STYLE_ROUNDED_CORNERS, \
+        }, \
+        .dim = { .min_width = (W), .min_height = (H) }, \
+        .text = (TEXT), \
+        __VA_ARGS__ \
+    })
+
+#define gui_label(GUI, TEXT, W, H, ...) \
+    gui_ui_compose_begin((GUI), (ui_config_t){ \
+        .composition = { .styles = UI_STYLE_ONLY_TEXT }, \
+        .dim = { .min_width = (W), .min_height = (H) }, \
+        .color = { .base = COLOR_WHITE }, \
+        .text = (TEXT), \
+        __VA_ARGS__ \
+    })
+
+#define gui_panel(GUI, W, H, ...) \
+    gui_ui_compose_begin((GUI), (ui_config_t){ \
+        .dim = { .min_width = (W), .min_height = (H) }, \
+        .color = { .base = COLOR_BLACK }, \
+        __VA_ARGS__ \
+    })
+
 
 void    gui_render(gui_t *self);
 void    gui_destroy(gui_t *self);
@@ -185,9 +226,7 @@ void gui_destroy(gui_t *self)
     list_destroy(&self->gfx.instanced_attrs);
 }
 
-ui_region_t gui__internal_get_current_region(gui_t *gui,const ui_config_t config);
-
-void gui__internal_update_state(gui_t *gui, ui_config_t config)
+void gui__internal_update_state(gui_t *gui, const ui_config_t config)
 {
     window_t *win = window_get_current_active_window();
     const vec2i_t mouse_pos = window_mouse_get_position(win);
@@ -202,19 +241,19 @@ void gui__internal_update_state(gui_t *gui, ui_config_t config)
         && (f32)mouse_pos.y > region.cursor.y
         && (f32)mouse_pos.y < region.cursor.y + region.height;
 
-    gui->state.hovered_ui_id = is_cursor_on_ui 
-        ? config.id 
+    gui->state.hovered_ui_id = is_cursor_on_ui
+        ? config.id
         : gui->state.hovered_ui_id;
 }
 
-bool gui__internal_is_cursor_on_ui(gui_t *gui, ui_config_t config)
+bool gui__internal_is_cursor_on_ui(const gui_t *gui, const ui_config_t config)
 {
     return gui->state.hovered_ui_id != 0 && config.id == gui->state.hovered_ui_id;
 }
 
-vec4f_t gui__internal_get_color(gui_t *gui, ui_config_t config)
+vec4f_t gui__internal_get_color(const gui_t *gui, const ui_config_t config)
 {
-    return gui__internal_is_cursor_on_ui(gui, config) ? config.color.highlight :config.color.base;
+    return gui__internal_is_cursor_on_ui(gui, config) ? config.color.highlight : config.color.base;
 }
 
 void gui__internal_ui_push_cursor_layout(gui_t *gui, const layout_ctx_t old_cursor__updated, const layout_ctx_t new_cursor)
@@ -231,11 +270,13 @@ void gui__internal_ui_pop_cursor_layout(gui_t *gui)
     --gui->internal.layout_cursor_stack.top;
 }
 
-vec2f_t gui__internal_get_active_cursor(gui_t *gui)
+vec2f_t gui__internal_get_current_cursor(const gui_t *gui)
 {
-    return gui->internal
+    const ui_region_t region = gui->internal
         .layout_cursor_stack
-        .buffer[gui->internal.layout_cursor_stack.top].region.cursor;
+        .buffer[gui->internal.layout_cursor_stack.top].region;
+
+    return region.cursor;
 }
 
 void gui_ui_compose_end(gui_t *gui)
@@ -243,7 +284,7 @@ void gui_ui_compose_end(gui_t *gui)
     gui__internal_ui_pop_cursor_layout(gui);
 }
 
-void gui__internal_ui_validate_config(ui_config_t config)
+void gui__internal_ui_validate_config(const ui_config_t config)
 {
     ASSERT(config.dim.min_height > 0);
     ASSERT(config.dim.min_width > 0);
@@ -263,66 +304,68 @@ ui_region_t gui__internal_ui_add_child(gui_t *gui, const ui_config_t config)
         .buffer[gui->internal.layout_cursor_stack.top];
 
     const ui_region_t parent_region = parent_layout.region;
-    const u32 width_enclosed_by_child_region = config.margin.left + config.dim.min_width + config.margin.right;
+    const vec2f_t current_cursor = gui__internal_get_current_cursor(gui);
 
-    //1. Does child fit in parent's region
-    //2. Extend size of parent to encapsulate the child
-    //3. Have this behavior be configurable
+    f32 child_width  = (f32)config.dim.min_width;
+    f32 child_height = (f32)config.dim.min_height;
 
-    const vec2f_t current_cursor = gui__internal_get_active_cursor(gui);
+    if (config.size_mode == UI_SIZE_FILL) {
+        child_width = parent_region.width - (f32)(config.margin.left + config.margin.right);
+        child_height = parent_layout.region.height - (f32)(config.margin.top + config.margin.bottom);
+    }
+
+    const f32 width_enclosed_by_child_region = (f32)config.margin.left + child_width + (f32)config.margin.right;
 
     ui_region_t child_region = {
-        .cursor.x = current_cursor.x + config.margin.left,
-        .cursor.y = current_cursor.y + config.margin.top,
-        .width  = config.dim.min_width,
-        .height = config.dim.min_height
+        .cursor.x = current_cursor.x + (f32)config.margin.left,
+        .cursor.y = current_cursor.y + (f32)config.margin.top,
+        .width  = child_width,
+        .height = child_height
     };
 
-    const u32 next_active_cursor_x = current_cursor.x + width_enclosed_by_child_region;
+    const f32 next_active_cursor_x = current_cursor.x + width_enclosed_by_child_region;
 
-    const bool is_child_region_at_end_parent_layout_width = next_active_cursor_x > 
-        ((u32)parent_layout.starting_region.cursor.x + parent_region.width);
+    const bool is_child_region_at_end_parent_layout_width = next_active_cursor_x >
+        (parent_layout.starting_region.cursor.x + parent_region.width);
 
     if (is_child_region_at_end_parent_layout_width) {
         child_region.cursor = (vec2f_t){
-            .x = parent_layout.starting_region.cursor.x + config.margin.left,
-            .y = current_cursor.y + parent_layout.max_row_height + config.margin.top,
+            .x = parent_layout.starting_region.cursor.x + (f32)config.margin.left,
+            .y = current_cursor.y + (f32)parent_layout.max_row_height + (f32)config.margin.top,
         };
     }
 
-    const u32 row_height_inclosed_by_child_region = config.margin.top + config.margin.bottom + config.dim.min_height;
+    const f32 row_height = (f32)config.margin.top + (f32)config.margin.bottom + child_height;
 
     gui__internal_ui_push_cursor_layout(
-        gui, 
+        gui,
         (layout_ctx_t) {
             .region = (ui_region_t) {
-                .cursor = is_child_region_at_end_parent_layout_width 
+                .cursor = is_child_region_at_end_parent_layout_width
                     ? (vec2f_t){
                         parent_layout.starting_region.cursor.x + width_enclosed_by_child_region,
-                        current_cursor.y + parent_layout.max_row_height 
+                        current_cursor.y + (f32)parent_layout.max_row_height
                     }
                     : (vec2f_t){
                         next_active_cursor_x,
-                        current_cursor.y 
+                        current_cursor.y
                     },
                 .width = parent_region.width,
                 .height = parent_region.height
             },
-            .max_row_height = !is_child_region_at_end_parent_layout_width 
-                ? MAX(parent_layout.max_row_height, row_height_inclosed_by_child_region)
-                : 0,
+            .max_row_height = MAX(parent_layout.max_row_height, (u32)row_height),
             .starting_region = parent_layout.starting_region
         },
         (layout_ctx_t) {
             .region = {
-                .cursor = (vec2f_t){ 
-                    .x = child_region.cursor.x + config.padding.left,
-                    .y = child_region.cursor.y + config.padding.top
+                .cursor = (vec2f_t){
+                    .x = child_region.cursor.x + (f32)config.padding.left,
+                    .y = child_region.cursor.y + (f32)config.padding.top
                 },
                 .height = child_region.height,
                 .width = child_region.width
             },
-            .max_row_height = child_region.height,
+            .max_row_height = (u32)child_region.height,
             .starting_region = child_region
         }
     );
@@ -332,11 +375,20 @@ ui_region_t gui__internal_ui_add_child(gui_t *gui, const ui_config_t config)
 void gui__internal_ui_create_text_internal(gui_t * const gui, const ui_region_t child_region, const ui_config_t config)
 {
     vec2f_t starting_pos = child_region.cursor;
-    const f32 offset = config.dim.min_width / config.text.len;
+
+    f32 total_text_width = 0.0f;
+    for (u32 i = 0; i < config.text.len; i++)
+        total_text_width += gui->freetypefont.fontatlas[(u8)config.text.data[i]].ax;
+
+    if (config.text_align == UI_TEXT_ALIGN_CENTER)
+        starting_pos.x = child_region.cursor.x + (child_region.width - total_text_width) / 2.0f;
+    else if (config.text_align == UI_TEXT_ALIGN_RIGHT)
+        starting_pos.x = child_region.cursor.x + child_region.width - total_text_width;
+
     for (u32 i = 0; i < config.text.len; i++)
     {
         const box_t quad = glfreetypefont_generate_uv_for_char(
-                &gui->freetypefont, 
+                &gui->freetypefont,
                 config.text.data[i]);
 
         const u8 character = config.text.data[i];
@@ -348,8 +400,8 @@ void gui__internal_ui_create_text_internal(gui_t * const gui, const ui_region_t 
 
         const ui_attr_t attr = {
             .position = {
-                .cursor = { 
-                    floorf(starting_pos.x + bearing_x + bearing_x), 
+                .cursor = {
+                    floorf(starting_pos.x + bearing_x),
                     floorf(starting_pos.y + (gui->freetypefont.fontsize - bearing_y))
                 },
                 .height = glyph_h,
@@ -369,9 +421,11 @@ void gui__internal_ui_create_text_internal(gui_t * const gui, const ui_region_t 
 void gui_ui_compose_begin(gui_t * const gui, const ui_config_t config)
 {
     gui__internal_ui_validate_config(config);
+
     const ui_region_t child_region = gui__internal_ui_add_child(gui, config);
 
     gui__internal_update_state(gui, config);
+
     const vec4f_t computed_color = gui__internal_get_color(gui, config);
 
     if (config.composition.styles & UI_STYLE_ONLY_TEXT) {
@@ -384,6 +438,9 @@ void gui_ui_compose_begin(gui_t * const gui, const ui_config_t config)
         .color = computed_color,
         .zorder = gui->internal.layout_cursor_stack.top,
         .uv = {0},
+        .corner_radius = (config.composition.styles & UI_STYLE_ROUNDED_CORNERS)
+            ? (f32)config.corner_radius
+            : 0.0f,
         .is_text = false,
     };
     list_append(&gui->gfx.instanced_attrs, attr);
@@ -463,7 +520,7 @@ void gui_render(gui_t *self)
                         }
                     },
                     .attrs = {
-                        .count = 6,
+                        .count = 7,
                         .attr = {
                             [0] = {
                                 .ncmp = 2,
@@ -513,6 +570,15 @@ void gui_render(gui_t *self)
                                 .vbo_chunk_index = VBO_STREAM_TYPE_INSTANCE,
                                 .interleaved = {
                                     .offset = offsetof(ui_attr_t, is_text),
+                                    .stride = sizeof(ui_attr_t)
+                                }
+                            },
+                            [6] = {
+                                .ncmp = 1,
+                                .type = GL_FLOAT,
+                                .vbo_chunk_index = VBO_STREAM_TYPE_INSTANCE,
+                                .interleaved = {
+                                    .offset = offsetof(ui_attr_t, corner_radius),
                                     .stride = sizeof(ui_attr_t)
                                 }
                             }

--- a/gui.h
+++ b/gui.h
@@ -421,8 +421,11 @@ void gui_ui_compose_begin(gui_t * const gui, const ui_config_t config)
     };
     list_append(&gui->gfx.instanced_attrs, attr);
 
-    if (config.text.len > 0)
-        gui__internal_ui_create_text_internal(gui, child_region, config);
+    if (config.text.len > 0) {
+        ui_config_t text_cfg = config;
+        text_cfg.color.base = (vec4f_t){1.0f, 1.0f, 1.0f, 1.0f};
+        gui__internal_ui_create_text_internal(gui, child_region, text_cfg);
+    }
 }
 
 void gui_button(gui_t *gui, u32 id, str_t text, f32 w, f32 h, ui_config_t cfg)

--- a/gui/uishader-frag.glsl
+++ b/gui/uishader-frag.glsl
@@ -4,16 +4,28 @@ out vec4 FragColor;
 in vec4 v_Color;
 in vec2 v_UV;
 in float v_is_text;
+in vec2 v_quad_coord;
+in float v_corner_radius;
 
 uniform sampler2D fontTexture;
+
+float rounded_box_sdf(vec2 p, vec2 size, float radius)
+{
+    vec2 d = abs(p) - size + radius;
+    return length(max(d, 0.0)) - radius;
+}
 
 void main()
 {
     if (v_is_text == 1.0) {
-        // Sample the glyph mask (Red channel)
         FragColor = v_Color * texture(fontTexture, v_UV).r;
     } else {
-        // Non-text elements (quads/buttons) still use their assigned color
         FragColor = v_Color;
+        if (v_corner_radius > 0.0) {
+            vec2 p = abs(v_quad_coord - 0.5);
+            float d = rounded_box_sdf(p, vec2(0.5), v_corner_radius);
+            float alpha = clamp(1.0 - d, 0.0, 1.0);
+            FragColor.a *= alpha;
+        }
     }
 }

--- a/gui/uishader-vtx.glsl
+++ b/gui/uishader-vtx.glsl
@@ -9,18 +9,23 @@ layout (location = 2) in vec4 region_color;  // [r, g, b, a]
 layout (location = 3) in float zorder; 
 layout (location = 4) in vec4 uv_rect; // [x, y, w, h] in pixels
 layout (location = 5) in float is_text; 
+layout (location = 6) in float corner_radius; 
 
 uniform mat4 projection;
 
 out vec4 v_Color;
 out vec2 v_UV;
 out float v_is_text;
+out vec2 v_quad_coord;
+out float v_corner_radius;
 
 void main()
 {
     v_Color = region_color;
     v_UV = uv_rect.xy + (quad_vtx * uv_rect.zw);
     v_is_text = is_text;
+    v_quad_coord = quad_vtx;
+    v_corner_radius = corner_radius;
 
     // Instance Position calculation: 
     // We scale the unit quad by width/height and offset by x/y

--- a/util/workbench.h
+++ b/util/workbench.h
@@ -5,6 +5,7 @@
 #include "./workbench/common.h"
 #include "./workbench/ui/workbench-ui.h"
 #include "./workbench/workbench-grid.h"
+#include "SDL_keycode.h"
 #include "poglib/ecs/component/types.h"
 #include "poglib/gui.h"
 #include "poglib/util/workbench/workbench-editor.h"
@@ -225,6 +226,12 @@ workbench_t * workbench_init(arena_t *const arena)
                 [WORKBENCH_ACTION_TYPE_CAMERA_ZOOM_OUT] = {
                     .type = COMMANDINPUTKEY_TYPE_MOUSE,
                     .sdl_mouse.wheel = SDL_MOUSEWHEEL_DOWN,
+                },
+                [WORKBENCH_ACTION_TYPE_EDITOR_CANCEL_EDIT] = {
+                    .type = COMMANDINPUTKEY_TYPE_KEYBOARD,
+                    .sdl_keyboard_key = {
+                        .scancode = SDL_SCANCODE_ESCAPE
+                    }
                 },
             },
         }
@@ -522,9 +529,25 @@ void workbench_update(const f32 dt)
 
     workbench_editor_update();
 
-    if (bitmask & (1 << WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_JUST_CLICKED))
-    {
-        global_workbench->editor.selected_entity_id = global_workbench->editor.mouse_closest_to_entity_id;
+    if (bitmask & (1 << WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_JUST_CLICKED))   {
+
+        if (global_workbench->editor.prevmouseclicked_entity_Id != global_workbench->editor.mouse_closest_to_entity_id) {
+            global_workbench->editor.mouseclick_counter = 0;
+        } else {
+            ++global_workbench->editor.mouseclick_counter;
+        }
+
+        if (global_workbench->editor.mouseclick_counter == 2) {
+            global_workbench->editor.selected_entity_id = global_workbench->editor.mouse_closest_to_entity_id;
+        }
+
+        global_workbench->editor.prevmouseclicked_entity_Id = global_workbench->editor.mouse_closest_to_entity_id;
+        printf("click registered %i \n", global_workbench->editor.mouseclick_counter);
+    }
+
+    if (bitmask & (1 << WORKBENCH_ACTION_TYPE_EDITOR_CANCEL_EDIT))              {
+        global_workbench->editor.selected_entity_id = 0;
+        global_workbench->editor.mouseclick_counter = 0;
     }
 
     ecs_patch_entity(
@@ -536,6 +559,7 @@ void workbench_update(const f32 dt)
             .signature = ECS_CMP_TRANSFORM
         }
     );
+
 }
 
 void workbench_toggle(void)

--- a/util/workbench/common.h
+++ b/util/workbench/common.h
@@ -8,11 +8,11 @@
 
 
 typedef enum workbench_action_type {
-    WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_DRAG         = 0,
-    WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_JUST_CLICKED = 1,
-    WORKBENCH_ACTION_TYPE_CAMERA_ZOOM_IN                = 2,
-    WORKBENCH_ACTION_TYPE_CAMERA_ZOOM_OUT               = 3,
-    WORKBENCH_ACTION_TYPE_CANCEL_ACTION                 = 4,
+    WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_DRAG             = 0,
+    WORKBENCH_ACTION_TYPE_MOUSE_LEFT_CLICK_JUST_CLICKED     = 1,
+    WORKBENCH_ACTION_TYPE_CAMERA_ZOOM_IN                    = 2,
+    WORKBENCH_ACTION_TYPE_CAMERA_ZOOM_OUT                   = 3,
+    WORKBENCH_ACTION_TYPE_EDITOR_CANCEL_EDIT                = 4,
     WORKBENCH_ACTION_TYPE_COUNT
 } workbench_action_type;
 
@@ -52,6 +52,9 @@ typedef struct {
     struct {
         u32 mouse_closest_to_entity_id;
         u32 selected_entity_id;
+
+        u32 prevmouseclicked_entity_Id;
+        u32 mouseclick_counter;
     } editor;
 
 } workbench_t;

--- a/util/workbench/ui/workbench-ui.h
+++ b/util/workbench/ui/workbench-ui.h
@@ -21,6 +21,15 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
     const u32 window_width = global_window->width;
     char tempbuffer[32] = {0};
 
+    gui_ui_compose_begin(gui, (ui_config_t){
+        .color = {
+            .base = COLOR_WHITE,
+        },
+        .dim = {
+            .min_height = 60,
+            .min_width = global_window->width
+        },
+    });
     //FPS Counter
     gui_ui_compose_begin(gui, (ui_config_t){ 
         .composition = {
@@ -31,7 +40,7 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         },
         .dim = {
             .min_height = 30,
-            .mid_width = 80 
+            .min_width = 80 
         },
         .padding = {4,4,4,4},
         .margin = {
@@ -45,17 +54,19 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         const f32 fps = application_get_fps(global_engine->handle.app);
         snprintf(tempbuffer, sizeof(tempbuffer), "FPS: %d", (int)fps);
         gui_ui_compose_begin(gui, (ui_config_t){ 
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .color = {
                 .base = COLOR_OFFWHITE,
             },
             .dim = {
                 .min_height = 40,
-                .mid_width = 40 
+                .min_width = 40 
             },
             .padding = {0},
             .margin = {0},
-            .label = str__from_cstr(tempbuffer, sizeof(tempbuffer))
+            .text = str__from_cstr(tempbuffer, sizeof(tempbuffer))
         });
         gui_ui_compose_end(gui);
     } 
@@ -71,9 +82,9 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         },
         .dim = {
             .min_height = 30,
-            .mid_width = 140 
+            .min_width = 140 
         },
-        .padding = {8,4,4,4},
+        .padding = {4,4,4,8},
         .margin = {
             .left = 5, 
             .right = 5,
@@ -86,17 +97,19 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         memset(tempbuffer, 0, sizeof(tempbuffer));
         snprintf(tempbuffer, sizeof(tempbuffer), "NDC [ %.2f, %.2f ]", mouse_pos.x, mouse_pos.y);
         gui_ui_compose_begin(gui, (ui_config_t){ 
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .color = {
                 .base = COLOR_SOFT_WHITE,
             },
             .dim = {
                 .min_height = 20,
-                .mid_width = 100 
+                .min_width = 100 
             },
             .padding = {0},
             .margin = {2,2,2,2},
-            .label = str__from_cstr(tempbuffer, sizeof(tempbuffer))
+            .text = str__from_cstr(tempbuffer, sizeof(tempbuffer))
         });
         gui_ui_compose_end(gui);
 
@@ -104,17 +117,19 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         const vec2i_t mouse_pos_wc = window_mouse_get_position(global_window);
         snprintf(tempbuffer, sizeof(tempbuffer), "WDC [ %i, %i ]", mouse_pos_wc.x, mouse_pos_wc.y);
         gui_ui_compose_begin(gui, (ui_config_t){ 
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .color = {
                 .base = COLOR_SOFT_WHITE,
             },
             .dim = {
                 .min_height = 20,
-                .mid_width = 100 
+                .min_width = 100 
             },
             .padding = {0},
             .margin = {0},
-            .label = str__from_cstr(tempbuffer, sizeof(tempbuffer))
+            .text = str__from_cstr(tempbuffer, sizeof(tempbuffer))
         });
         gui_ui_compose_end(gui);
     } 
@@ -130,9 +145,9 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         },
         .dim = {
             .min_height = 30,
-            .mid_width = 200 
+            .min_width = 200 
         },
-        .padding = {8,4,4,4},
+        .padding = {4,4,4,8},
         .margin = {
             .left = 5, 
             .right = 5,
@@ -145,17 +160,19 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         memset(tempbuffer, 0, sizeof(tempbuffer));
         snprintf(tempbuffer, sizeof(tempbuffer), "cam pos [ %.2f, %.2f, %.2f ]", camera_pos.x, camera_pos.y, camera_pos.z);
         gui_ui_compose_begin(gui, (ui_config_t){ 
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .color = {
                 .base = COLOR_SOFT_WHITE,
             },
             .dim = {
                 .min_height = 40,
-                .mid_width = 80 
+                .min_width = 80 
             },
             .padding = {0},
             .margin = {0},
-            .label = str__from_cstr(tempbuffer, sizeof(tempbuffer))
+            .text = str__from_cstr(tempbuffer, sizeof(tempbuffer))
         });
         gui_ui_compose_end(gui);
     } 
@@ -169,7 +186,7 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
         .id = WB_COLLIDER_TOGGLE,
         .dim = {
             .min_height = 30,
-            .mid_width = 120,
+            .min_width = 120,
         },
         .color = {
             .base = COLOR_WHITE,
@@ -190,19 +207,22 @@ void workbench_compose_ui(gui_t *const gui, const vec3f_t camera_pos)
     });{
         gui_ui_compose_begin(gui, (ui_config_t) {
             .id = WB_COLLIDER_TOGGLE,
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .dim = {
                 .min_height = 40,
-                .mid_width = 40,
+                .min_width = 40,
             },
             .color = {
                 .base = COLOR_BLACK,
                 .highlight = COLOR_BLUE
             },
-            .label = str("show colliders"),
+            .text = str("show colliders"),
         });
         gui_ui_compose_end(gui);
     }
+    gui_ui_compose_end(gui);
     gui_ui_compose_end(gui);
 }
 
@@ -225,7 +245,7 @@ void workbench__internal_compose_ui__test(const application_t * const app, gui_t
         },
         .dim = {
             .min_height = 100,
-            .mid_width = 100 
+            .min_width = 100 
         },
         .padding = {
             10, 10, 10, 10
@@ -238,18 +258,20 @@ void workbench__internal_compose_ui__test(const application_t * const app, gui_t
         }
     });
         gui_ui_compose_begin(gui, (ui_config_t){ 
-            .composition = {0},
+            .composition = {
+                .styles = UI_STYLE_ONLY_TEXT
+            },
             .color = {
                 .base = COLOR_WHITE,
                 .highlight = COLOR_CYAN,
             },
             .dim = {
                 .min_height = 40,
-                .mid_width = 80 
+                .min_width = 80 
             },
             .padding = {0},
             .margin = {0},
-            .label = str("Hello World")
+            .text = str("Hello World")
         });
         gui_ui_compose_end(gui);
     gui_ui_compose_end(gui);
@@ -266,7 +288,7 @@ void workbench__internal_compose_ui__test(const application_t * const app, gui_t
             },
             .dim = {
                 .min_height = 50,
-                .mid_width = 50
+                .min_width = 50
             },
             .padding = {0},
             .margin = {
@@ -286,7 +308,7 @@ void workbench__internal_compose_ui__test(const application_t * const app, gui_t
                 },
                 .dim = {
                     .min_height = 10,
-                    .mid_width = 10
+                    .min_width = 10
                 },
                 .padding = {0},
                 .margin = {

--- a/util/workbench/workbench-editor.h
+++ b/util/workbench/workbench-editor.h
@@ -69,26 +69,32 @@ void workbench_editor__internal_show_entity_info_for_selected_entity(void)
     if (!global_workbench->editor.selected_entity_id) return;
 
     gui_t *const gui = &global_workbench->gui.handle;
+    printf("selected entityId = %i\n", global_workbench->editor.selected_entity_id);
 
     gui_ui_compose_begin(gui, (ui_config_t) {
             .dim = {
-                .min_width = 200,
-                .min_height = 200,
+                .min_width = 150,
+                .min_height = 150,
             },
             .margin = {
                 .top = 20.f,
                 .left = 20.f
             },
             .color = {
-                .base = COLOR_DARK_GRAY
+                .base = COLOR_BLACK
             }
     });
-        gui_ui_compose_begin(gui, (ui_config_t) {
-                .id = 1,
-                .text = str("show transform"),
+    for (u8 idx = 0; idx < 3; idx ++)
+    {
+        const str_t options[3] = {
+            str("T"),
+            str("R"),
+            str("S"),
+        };
+            gui_ui_compose_begin(gui, (ui_config_t) {
+                .id = idx + 2,
                 .composition = {
-                    .styles = UI_STYLE_ONLY_TEXT,
-                    .traits = UI_BEHAVIOR_CLICKABLE 
+                    .traits = UI_BEHAVIOR_HOVERABLE | UI_BEHAVIOR_CLICKABLE 
                 },
                 .dim = {
                     .min_width = 20,
@@ -99,52 +105,30 @@ void workbench_editor__internal_show_entity_info_for_selected_entity(void)
                     .left = 20.f
                 },
                 .color = {
-                    .base = COLOR_WHITE
+                    .base = COLOR_GRAY,
+                    .highlight = COLOR_DARK_GRAY
                 }
-        });
-        gui_ui_compose_end(gui);
-        gui_ui_compose_begin(gui, (ui_config_t) {
-                .id = 2,
-                .text = str("rotation"),
-                .composition = {
-                    .traits = UI_BEHAVIOR_CLICKABLE,
-                    .styles = UI_STYLE_ONLY_TEXT
-                },
-                .dim = {
-                    .min_width = 15,
-                    .min_height = 10,
-                },
-                .margin = {
-                    .top = 20.f,
-                    .left = 20.f
-                },
-                .color = {
-                    .base = COLOR_WHITE
-                }
-        });
-        gui_ui_compose_end(gui);
-        gui_ui_compose_begin(gui, (ui_config_t) {
-                .id = 3,
-                .text = str("scale"),
-                .composition = {
-                    .styles = UI_STYLE_ONLY_TEXT,
-                    .traits = UI_BEHAVIOR_CLICKABLE 
-                },
-                .dim = {
-                    .min_width = 15,
-                    .min_height = 10,
-                },
-                .margin = {
-                    .top = 20.f,
-                    .left = 20.f
-                },
-                .color = {
-                    .base = COLOR_WHITE
-                }
-        });
-        gui_ui_compose_end(gui);
+            });
+
+                gui_ui_compose_begin(gui, (ui_config_t) {
+                        .text = options[idx],
+                        .composition = {
+                            .styles = UI_STYLE_ONLY_TEXT,
+                        },
+                        .dim = {
+                            .min_width = 10,
+                            .min_height = 10,
+                        },
+                        .color = {
+                            .base = COLOR_WHITE
+                        }
+                }); gui_ui_compose_end(gui);
+
+            gui_ui_compose_end(gui);
+    }
     gui_ui_compose_end(gui);
 }
+
 
 void workbench_editor_render(void)
 {


### PR DESCRIPTION
…t correctness, helper macros

BUG FIXES:
- Fix double bearing_x in text rendering (bearing_x+bearing_x -> bearing_x)
- Fix u32 truncation of float layout coordinates (use f32 throughout)
- Remove dead gui__internal_get_current_region declaration
- Fix max_row_height reset on newline (maintain row tracking)
- Reorder padding/margin/border to TRBL convention {top,right,bottom,left}
- Update all positional padding initializers in workbench-ui.h

FEATURES:
- Add ui_text_align enum (LEFT/CENTER/RIGHT) with implementation
- Add ui_size_mode enum (WRAP/FILL) for fill-to-parent sizing
- Implement rounded corners via SDF in fragment shader
- Plumb corner_radius from config through attr to shader attribute #6

QUALITY:
- Add const qualifiers to read-only function parameters
- Add helper macros: gui_button(), gui_label(), gui_panel()
- Remove stale vec2ui_t comment (now vec2f_t)
- Update TODO list (remove Rounded Corners as implemented)