### PR TITLE
Fix MSVC build: rename near/far NDC variables in workbench editor

### DIFF
--- a/util/workbench/workbench-editor.h
+++ b/util/workbench/workbench-editor.h
@@ -36,11 +36,11 @@ void workbench_editor__internal_check_mouse_closest_entity(void)
         const matrix4f_t view       = glcamera_getview(cam);
         const matrix4f_t proj       = glms_perspective(radians(45), global_engine->handle.app->window.aspect_ratio, 0.1f, 1000.0f);
         const matrix4f_t inv_pv     = glms_mat4_inv(glms_mat4_mul(proj, view));
-        const vec4f_t near          = { ndc.x, ndc.y, -1.0f, 1.0f };
-        const vec4f_t far           = { ndc.x, ndc.y,  1.0f, 1.0f };
+        const vec4f_t near_ndc     = { ndc.x, ndc.y, -1.0f, 1.0f };
+        const vec4f_t far_ndc      = { ndc.x, ndc.y,  1.0f, 1.0f };
 
-        vec4f_t near_w      = glms_mat4_mulv(inv_pv, near);
-        vec4f_t far_w       = glms_mat4_mulv(inv_pv, far);
+        vec4f_t near_w      = glms_mat4_mulv(inv_pv, near_ndc);
+        vec4f_t far_w       = glms_mat4_mulv(inv_pv, far_ndc);
         near_w              = glms_vec4_scale(near_w, 1.0f / near_w.w);
         far_w               = glms_vec4_scale(far_w,  1.0f / far_w.w);
 


### PR DESCRIPTION
## Summary
- Rename 
ear and ar to 
ear_ndc and ar_ndc in workbench_editor__internal_check_mouse_closest_entity.
- Fixes Windows/MSVC builds where legacy windows.h macros collide with those variable names and produce compile errors (C2513, C2059).

## Test plan
- [x] Build on Windows with MSVC (uild.bat) — compiles successfully after this change
- [ ] Verify workbench editor entity picking still works (mouse ray from NDC to world space unchanged)

Made with [Cursor](https://cursor.com)