### PR TITLE
fix: call timeBeginPeriod(1) once at startup for Windows timer precision

### DIFF
--- a/application/stopwatch.h
+++ b/application/stopwatch.h
@@ -7,6 +7,9 @@
 #include <SDL2/SDL.h>
 #endif
 #include <poglib/basic.h>
+#ifdef _WIN64
+#include <timeapi.h>
+#endif
 
 
 /*=============================================================================
@@ -60,6 +63,9 @@ void stopwatch_delay(const f32 ms)
 
 stopwatch_t stopwatch(void)
 {
+#ifdef _WIN64
+    timeBeginPeriod(1);
+#endif
     stopwatch_t output = {0};
     output.now = stopwatch_get_tick();
     output.raw_dt = 0.01f;


### PR DESCRIPTION
On Windows, SDL_GetTicks() defaults to ~15ms granularity. timeBeginPeriod(1) bumps it to 1ms. Previously this call was misplaced inside stopwatch_get_tick() where its return value (status code) was used as the tick value.

Fix: timeBeginPeriod(1) called once at startup in stopwatch() init. stopwatch_get_tick() continues returning SDL_GetTicks() on all platforms.