### PR TITLE
fix: correct quaternion-to-matrix in instance vertex shader (R^T -> R)

### DIFF
--- a/pipeline/render/shader/instance-line-vtx.glsl
+++ b/pipeline/render/shader/instance-line-vtx.glsl
@@ -32,9 +32,9 @@ void main()
     float tyy = ty * q.y, tyz = tz * q.y, tzz = tz * q.z;
 
     mat3 rot = mat3(
-        1.0 - (tyy + tzz),      txy - twz,              txz + twy,
-        txy + twz,              1.0 - (txx + tzz),      tyz - twx,
-        txz - twy,              tyz + twx,              1.0 - (txx + tyy)
+        1.0 - (tyy + tzz),      txy + twz,              txz - twy,
+        txy - twz,              1.0 - (txx + tzz),      tyz + twx,
+        txz + twy,              tyz - twx,              1.0 - (txx + tyy)
     );
 
     vec3 transformed_pos = (rot * (v_vtx * data.scale.xyz)) + data.translation.xyz;

--- a/pipeline/render/shader/instance-line-vtx.glsl
+++ b/pipeline/render/shader/instance-line-vtx.glsl
@@ -32,9 +32,9 @@ void main()
     float tyy = ty * q.y, tyz = tz * q.y, tzz = tz * q.z;
 
     mat3 rot = mat3(
-        1.0 - (tyy + tzz),      txy + twz,              txz - twy,
-        txy - twz,              1.0 - (txx + tzz),      tyz + twx,
-        txz + twy,              tyz - twx,              1.0 - (txx + tyy)
+        1.0 - (tyy + tzz),      txy - twz,              txz + twy,
+        txy + twz,              1.0 - (txx + tzz),      tyz - twx,
+        txz - twy,              tyz + twx,              1.0 - (txx + tyy)
     );
 
     vec3 transformed_pos = (rot * (v_vtx * data.scale.xyz)) + data.translation.xyz;

--- a/pipeline/render/shader/instance-vtx.glsl
+++ b/pipeline/render/shader/instance-vtx.glsl
@@ -36,9 +36,9 @@ void main()
     float tyy = ty * q.y, tyz = tz * q.y, tzz = tz * q.z;
 
     mat3 rot = mat3(
-        1.0 - (tyy + tzz),      txy - twz,              txz + twy,
-        txy + twz,              1.0 - (txx + tzz),      tyz - twx,
-        txz - twy,              tyz + twx,              1.0 - (txx + tyy)
+        1.0 - (tyy + tzz),      txy + twz,              txz - twy,
+        txy - twz,              1.0 - (txx + tzz),      tyz + twx,
+        txz + twy,              tyz - twx,              1.0 - (txx + tyy)
     );
 
     vec3 transformed_pos = (rot * (v_vtx * data.scale.xyz)) + data.translation.xyz;


### PR DESCRIPTION
## Problem
The GLSL instance vertex shader (instance-vtx.glsl) built the rotation matrix from a quaternion using the transposed convention (R^T), producing the inverse rotation. This caused meshes rendered via the instance path to rotate in the opposite direction from Jolt physics colliders and cglm model rendering.

The instance-line-vtx.glsl uses R^T intentionally because it receives orientations computed by `glms_quat_from_vecs(dir, +X)` (mapping dir->+X) and needs the inverse to transform the +X-axis line to point in 'dir'.

## Fix
Swapped the signs of the 6 off-diagonal w-cross terms in `instance-vtx.glsl` to produce the standard rotation matrix (R), matching cglm's `glms_quat_mat4` and Jolt.

## Verification
Build compiles and runs. Mesh orientation now matches Jolt collider wireframe orientation in the workbench editor.