### PR TITLE
feat(arena): capture backtraces in alloc records for flamegraph context

### DIFF
--- a/basic/arena_logger.h
+++ b/basic/arena_logger.h
@@ -1,9 +1,25 @@
 #pragma once
+
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "common.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+#if defined(__linux__)
+    #include <dlfcn.h>
+    #include <execinfo.h>
+#elif defined(_WIN64)
+    #include <windows.h>
+    #include <imagehlp.h>
+#endif
+
+#define ARENA_BACKTRACE_DEPTH 8
+#define ARENA_BACKTRACE_SKIP  2
 
 /*=============================================================================
                          - ARENA ALLOCATION LOGGER -
@@ -25,6 +41,8 @@ struct arena_alloc_record {
     int                  line;
     const char          *func;
     uint64_t             size;
+    char                *backtrace_frames[ARENA_BACKTRACE_DEPTH];
+    u32                  backtrace_count;
     arena_alloc_record_t *next;
 };
 
@@ -97,6 +115,54 @@ void arena_logger_log_alloc(arena_t *const arena, uint64_t size, const char *fil
     rec->line = line;
     rec->func = func;
     rec->size = size;
+
+#if defined(_WIN64)
+    {
+        void         *stack[ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1];
+        unsigned short frames = CaptureStackBackTrace(0, ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1, stack, NULL);
+        SYMBOL_INFO   *symbol = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + 256 * sizeof(char), 1);
+        symbol->MaxNameLen   = 255;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        HANDLE process = GetCurrentProcess();
+        SymInitialize(process, NULL, TRUE);
+
+        u32 count = 0;
+        for (int i = ARENA_BACKTRACE_SKIP + 1; i < (int)frames && count < ARENA_BACKTRACE_DEPTH; i++) {
+            if (SymFromAddr(process, (DWORD64)stack[i], 0, symbol)) {
+                rec->backtrace_frames[count] = (char *)calloc(256, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 255, "%s", symbol->Name);
+            } else {
+                rec->backtrace_frames[count] = (char *)calloc(32, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 31, "0x%p", stack[i]);
+            }
+            count++;
+        }
+        rec->backtrace_count = count;
+        free(symbol);
+    }
+#elif defined(__linux__)
+    {
+        void *array[ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1];
+        int frame_count = backtrace(array, ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1);
+        u32 count = 0;
+
+        for (int i = ARENA_BACKTRACE_SKIP + 1; i < frame_count && count < ARENA_BACKTRACE_DEPTH; i++) {
+            Dl_info info;
+            if (dladdr(array[i], &info) && info.dli_sname) {
+                rec->backtrace_frames[count] = (char *)calloc(256, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 255, "%s", info.dli_sname);
+            } else {
+                rec->backtrace_frames[count] = (char *)calloc(32, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 31, "%p", array[i]);
+            }
+            count++;
+        }
+        rec->backtrace_count = count;
+    }
+#else
+    rec->backtrace_count = 0;
+#endif
+
     rec->next = l->alloc_log_head;
     l->alloc_log_head = rec;
     l->alloc_log_count++;
@@ -110,6 +176,9 @@ void arena_logger_clear_log(arena_t *const arena)
     arena_alloc_record_t *cur = l->alloc_log_head;
     while (cur) {
         arena_alloc_record_t *next = cur->next;
+        for (u32 i = 0; i < cur->backtrace_count; i++) {
+            free(cur->backtrace_frames[i]);
+        }
         free(cur);
         cur = next;
     }
@@ -161,6 +230,9 @@ void arena_logger_dump_json(const char *filepath)
             snprintf(buf, sizeof(buf), "L%03d [%lu B]",
                      r->line, (unsigned long)r->size);
             arena_logger__internal_frame_lookup(buf, fname, &fc);
+            for (u32 b = 0; b < r->backtrace_count; b++) {
+                arena_logger__internal_frame_lookup(r->backtrace_frames[b], fname, &fc);
+            }
         }
     }
     arena_logger__internal_frame_lookup("(unused)", fname, &fc);
@@ -209,12 +281,20 @@ void arena_logger_dump_json(const char *filepath)
             cur += r->size;
             u64 norm_end = (u64)((double)cur * scale);
 
+            for (i32 b = (i32)r->backtrace_count - 1; b >= 0; b--) {
+                u32 bt_f = arena_logger__internal_frame_lookup(r->backtrace_frames[b], fname, &fc);
+                fprintf(f, ",\n      {\"type\": \"O\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_cur, bt_f);
+            }
             fprintf(f, ",\n      {\"type\": \"O\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_cur, file_f);
             fprintf(f, ",\n      {\"type\": \"O\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_cur, func_f);
             fprintf(f, ",\n      {\"type\": \"O\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_cur, detail_f);
             fprintf(f, ",\n      {\"type\": \"C\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_end, detail_f);
             fprintf(f, ",\n      {\"type\": \"C\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_end, func_f);
             fprintf(f, ",\n      {\"type\": \"C\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_end, file_f);
+            for (u32 b = 0; b < r->backtrace_count; b++) {
+                u32 bt_f = arena_logger__internal_frame_lookup(r->backtrace_frames[b], fname, &fc);
+                fprintf(f, ",\n      {\"type\": \"C\", \"at\": %lu, \"frame\": %u}", (unsigned long)norm_end, bt_f);
+            }
         }
 
         u64 end = base + l->capacity;

--- a/test/arena/build.sh
+++ b/test/arena/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+POGLIB_ROOT=$(dirname "$0")/../..
+POGLIB_DIR=$(cd "$POGLIB_ROOT" && pwd)
+gcc -I"$POGLIB_DIR"/.. -I"$POGLIB_DIR" -std=gnu11 -D_GNU_SOURCE -g -g3 -O0 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-sign-compare -Wno-type-limits -Wno-format -pthread -rdynamic -ldl main.c -o a.out && echo "Compiled successfully"


### PR DESCRIPTION
## Problem

The arena allocator tracks every `arena_reserve`/`arena_store` call with file, line, function, and byte count, dumping a speedscope-compatible JSON flamegraph at shutdown. However, when allocations go through shared utility functions (most notably `list.h` which is used throughout the entire codebase), **every allocation is attributed to the same source location**.

For example, `arena_reserve(arena, capacity * elem_size)` inside `list__internal__init` (list.h:87) always logs `file=list.h, func=list__internal__init` — regardless of which subsystem or object type triggered the allocation. This makes the arena map nearly useless for understanding real allocation patterns.

### Call chain before this change:
```
user_code()
  → list_init()                          ← arena_reserve macro expands here
    → list__internal__init(list.h:87)     ← BUT this is what gets logged
      → arena_reserve()
        → arena__internal__reserve_tracked()
          → arena_logger_log_alloc()
```
Log records only `file=list.h, line=87, func=list__internal__init`.

## Solution

Each `arena_alloc_record_t` now captures a **backtrace** at the allocation site using `backtrace()` + `dladdr()` (Linux) or `CaptureStackBackTrace` + `SymFromAddr` (Windows). The backtrace frames are emitted as **parent frames** in the speedscope JSON, so the flamegraph shows the full call chain above each allocation.

### Call chain after this change:
```
Speedscope flamegraph:
  arena_f
    backtrace[N-1]   ← user_code (e.g. "init_ecs_entities")
      ...
        backtrace[0] ← immediate caller of list func (e.g. "init_renderer")
          file_f     ← "list.h"
          func_f     ← "list__internal__init"
          detail_f   ← "L087 [200 B]"
```

## Implementation Details

| Constant | Value | Purpose |
|----------|-------|---------|
| `ARENA_BACKTRACE_DEPTH` | 8 | Max caller frames captured per allocation |
| `ARENA_BACKTRACE_SKIP` | 2 | Frames to skip (arena_logger_log_alloc + arena__internal__reserve_tracked) |

### Data structure changes
`arena_alloc_record_t` gains:
- `char *backtrace_frames[ARENA_BACKTRACE_DEPTH]` — pre-resolved symbol names
- `u32 backtrace_count` — number of frames captured

### Platform support
- **Linux**: `backtrace()` + `dladdr()` (requires `_GNU_SOURCE`)
- **Windows**: `CaptureStackBackTrace()` + `SymFromAddr()`
- **Fallback**: `backtrace_count = 0` (graceful no-op)

### JSON dump changes
Backtrace frames are emitted as nested `O`/`C` events between the arena frame and the file/func/detail frames. This follows the existing speedscope "evented" format pattern.

### Memory management
Backtrace frame strings are allocated with `calloc()` per allocation record and freed in `arena_logger_clear_log()` (called from `arena_clear()` and `arena_destroy()`).

### Self-contained header
The header now includes `<dlfcn.h>` and `<execinfo.h>` (or Windows equivalents) directly, with `_GNU_SOURCE` defined before any system header include. This avoids ordering issues when `arena_logger.h` is included from translation units that pull in `<features.h>` before `_GNU_SOURCE` is set.

## Testing

- All 16 arena test cases pass (single-threaded + multi-threaded): init, reserve, alignment, giveback reuse, store, clear, is_init, destroy, sub-arenas, many small allocs, parallel reserve, parallel giveback, mixed stress, sub-arena threading, parallel store
- Verified JSON dump output shows backtrace frames as parent events with resolved function names (e.g. `"mt_reserve_worker"`)
- Added `test/arena/build.sh` for Linux builds of the arena test suite

## Verification

Flamegraph format in dumped JSON:

```json
{"type": "O", "at": 500000, "frame": 5},   // backtrace: outermost caller (e.g. "start_thread")
{"type": "O", "at": 500000, "frame": 4},   // backtrace: intermediate (e.g. "mt_reserve_worker")
{"type": "O", "at": 500000, "frame": 1},   // file_f: "main.c"
{"type": "O", "at": 500000, "frame": 2},   // func_f: "mt_reserve_worker"
{"type": "O", "at": 500000, "frame": 3},   // detail_f: "L160 [16 B]"
{"type": "C", "at": 501953, "frame": 3},   // close detail_f
{"type": "C", "at": 501953, "frame": 2},   // close func_f
{"type": "C", "at": 501953, "frame": 1},   // close file_f
{"type": "C", "at": 501953, "frame": 4},   // close backtrace innermost
{"type": "C", "at": 501953, "frame": 5},   // close backtrace outermost
```