### PR TITLE
arena: add giveback tracking, text summary dump, and flat JSON export

### DIFF
--- a/application.h
+++ b/application.h
@@ -193,6 +193,8 @@ void application_run(application_t *const app)
     printf("[!] APPLICATION SHUTDOWN!\n");
 #ifdef DEBUG
     arena_logger_dump_json("arena_map.json");
+    arena_logger_dump_summary("arena_summary.txt");
+    arena_logger_dump_json_simple("arena_map_simple.json");
 #endif
     app->destroy(app);
     SDL_free((char *)app->context.base_dir);

--- a/basic/arena.h
+++ b/basic/arena.h
@@ -38,7 +38,11 @@ arena_t *   arena_init(arena_t *const, const u64 capacity);
 
 void *      arena_store(arena_t *const self, const void *const mem, const u64 mem_size);
 bool        arena_is_init(const arena_t *const self);
-void        arena_giveback(arena_t *const self, void *const ptr, const u64 size);
+void        arena__internal_giveback(arena_t *const self, void *const ptr, const u64 size);
+
+#define arena_giveback(self, ptr, size) \
+    arena__internal__giveback_tracked((self), (ptr), (size), __FILE__, __LINE__, __func__)
+
 void        arena_clear(arena_t *const self);
 void        arena_destroy(arena_t *const self);
 
@@ -78,7 +82,7 @@ void * arena__internal_check_in_freelist(arena_t *const self, const u64 memory_s
 
         self->freelist.count--;
         if (self->meta.lifetime_owner) {
-            arena_giveback(self->meta.lifetime_owner, chunk, sizeof(free_chunks_t));
+            arena__internal_giveback(self->meta.lifetime_owner, chunk, sizeof(free_chunks_t));
         } else {
             free(chunk);
         }
@@ -150,6 +154,12 @@ void * arena_store(arena_t * const self, const void * const mem, const u64 mem_s
     return raw_mem;
 }
 
+void arena__internal__giveback_tracked(arena_t *const self, void *const ptr, const u64 size, const char *file, int line, const char *func)
+{
+    arena__internal_giveback(self, ptr, size);
+    arena_logger_log_giveback(self, size, file, line, func);
+}
+
 arena_t * arena_init(arena_t *const arena, const u64 capacity)
 {
     const u64 final_capacity = capacity + sizeof(arena_t);
@@ -167,7 +177,7 @@ arena_t * arena_init(arena_t *const arena, const u64 capacity)
     return arena_store(&output, &output, sizeof(arena_t));
 }
 
-void arena_giveback(arena_t *const self, void *const ptr, const u64 size)
+void arena__internal_giveback(arena_t *const self, void *const ptr, const u64 size)
 {
     ASSERT(self);
     ASSERT(ptr);
@@ -226,7 +236,7 @@ void arena_destroy(arena_t *const self)
     arena_logger_destroy(self);
 
     if (self->meta.lifetime_owner) {
-        arena_giveback(self->meta.lifetime_owner, self->memory, self->capacity);
+        arena__internal_giveback(self->meta.lifetime_owner, self->memory, self->capacity);
         return;
     }
 
@@ -247,6 +257,175 @@ void arena_destroy(arena_t *const self)
 bool arena_is_init(const arena_t *const self)
 {
     return self && (self->memory != NULL || self->capacity > 0);
+}
+
+static const char *al__fmt_bytes(u64 bytes, char *buf, u32 buf_sz)
+{
+    if (bytes >= MB) {
+        snprintf(buf, buf_sz, "%.2f MB", (double)bytes / (double)MB);
+    } else if (bytes >= KB) {
+        snprintf(buf, buf_sz, "%.2f KB", (double)bytes / (double)KB);
+    } else {
+        snprintf(buf, buf_sz, "%lu B", (unsigned long)bytes);
+    }
+    return buf;
+}
+
+static u64 al__fl_bytes(arena_t *a)
+{
+    u64 sum = 0;
+    for (free_chunks_t *fc = a->freelist.head; fc; fc = fc->next) sum += fc->size;
+    return sum;
+}
+
+static void al__write_giveback_log(FILE *f, arena_t *a)
+{
+    arena_logger_t *l = arena_logger__internal_find(a);
+    if (!l || !l->giveback_log_count) return;
+
+    fprintf(f, "  Giveback log (%u entries):\n", l->giveback_log_count);
+    for (arena_giveback_record_t *r = l->giveback_log_head; r; r = r->next) {
+        char size_str[64];
+        al__fmt_bytes(r->size, size_str, sizeof(size_str));
+        fprintf(f, "    %s:%d (%s)  returned %s\n",
+                r->file, r->line, r->func, size_str);
+    }
+    fprintf(f, "\n");
+}
+
+void arena_logger_dump_summary(const char *filepath)
+{
+    FILE *f = fopen(filepath, "w");
+    if (!f) {
+        fprintf(stderr, "[arena_logger] Failed to open '%s' for writing\n", filepath);
+        return;
+    }
+
+    u64 total_capacity = 0, total_used = 0, total_unused = 0, total_fl_bytes = 0;
+    u32 total_allocs = 0, total_givebacks = 0, total_fl_chunks = 0;
+    u32 arena_count = 0;
+    for (arena_logger_t *lg = arena_logger_registry; lg; lg = lg->next) arena_count++;
+
+    fprintf(f, "================================================================================\n");
+    fprintf(f, "                         ARENA MEMORY REPORT  (%u arenas)\n", arena_count);
+    fprintf(f, "================================================================================\n\n");
+    fprintf(f, "%-50s %12s %12s %12s %7s %7s %14s\n",
+            "Arena (init location)", "Capacity", "Used", "Unused", "Allocs", "Gbacks", "Freelist(ch/B)");
+    fprintf(f, "------------------------------------------------------------------------------------------------------------------------\n");
+
+    for (arena_logger_t *lg = arena_logger_registry; lg; lg = lg->next) {
+        arena_t *a = lg->arena;
+        u64 used = a ? a->size : 0;
+        u64 unused = lg->capacity > used ? lg->capacity - used : 0;
+        u64 flb = a ? al__fl_bytes(a) : 0;
+        u32 flc = a ? a->freelist.count : 0;
+
+        char cap_str[32], used_str[32], unused_str[32], fl_str[64];
+        al__fmt_bytes(lg->capacity, cap_str, sizeof(cap_str));
+        al__fmt_bytes(used, used_str, sizeof(used_str));
+        al__fmt_bytes(unused, unused_str, sizeof(unused_str));
+        snprintf(fl_str, sizeof(fl_str), "%u / %lu B", flc, (unsigned long)flb);
+
+        const char *sub = a && a->meta.lifetime_owner ? "(sub)" : "";
+        char label[64];
+        snprintf(label, sizeof(label), "%s:%d %s", lg->init_file ? lg->init_file : "?", lg->init_line, sub);
+
+        fprintf(f, "%-50s %12s %12s %12s %7u %7u %14s\n",
+                label, cap_str, used_str, unused_str,
+                lg->alloc_log_count, lg->giveback_log_count, fl_str);
+
+        total_capacity  += lg->capacity;
+        total_used      += used;
+        total_unused    += unused;
+        total_allocs    += lg->alloc_log_count;
+        total_givebacks += lg->giveback_log_count;
+        total_fl_chunks += flc;
+        total_fl_bytes  += flb;
+    }
+
+    char tcap_str[32], tused_str[32], tunused_str[32], tfl_str[64];
+    al__fmt_bytes(total_capacity, tcap_str, sizeof(tcap_str));
+    al__fmt_bytes(total_used, tused_str, sizeof(tused_str));
+    al__fmt_bytes(total_unused, tunused_str, sizeof(tunused_str));
+    snprintf(tfl_str, sizeof(tfl_str), "%u / %lu B", total_fl_chunks, (unsigned long)total_fl_bytes);
+
+    fprintf(f, "------------------------------------------------------------------------------------------------------------------------\n");
+    fprintf(f, "%-50s %12s %12s %12s %7u %7u %14s\n",
+            "TOTAL", tcap_str, tused_str, tunused_str, total_allocs, total_givebacks, tfl_str);
+    fprintf(f, "\n================================================================================\n\n");
+    fprintf(f, "Usage breakdown by arena:\n");
+    fprintf(f, "------------------------------------------------------------------------------------------------------------------------\n");
+
+    for (arena_logger_t *lg = arena_logger_registry; lg; lg = lg->next) {
+        arena_t *a = lg->arena;
+        u64 used = a ? a->size : 0;
+        const char *sub = a && a->meta.lifetime_owner ? "(sub)" : "";
+        double pct_used = lg->capacity ? (double)used / (double)lg->capacity * 100.0 : 0.0;
+
+        char used_str[32], cap_str[32];
+        al__fmt_bytes(used, used_str, sizeof(used_str));
+        al__fmt_bytes(lg->capacity, cap_str, sizeof(cap_str));
+
+        fprintf(f, "  %s:%d %s\n", lg->init_file ? lg->init_file : "?", lg->init_line, sub);
+        fprintf(f, "    capacity = %s  |  used = %s (%.1f%%)  |  allocs = %u  |  givebacks = %u\n",
+                cap_str, used_str, pct_used, lg->alloc_log_count, lg->giveback_log_count);
+        if (a && a->freelist.count) {
+            fprintf(f, "    freelist: %u chunks, %lu bytes total\n", a->freelist.count, (unsigned long)al__fl_bytes(a));
+        }
+    }
+
+    fprintf(f, "\n================================================================================\n");
+    fprintf(f, "                        GIVEBACK DETAILS\n");
+    fprintf(f, "================================================================================\n\n");
+
+    for (arena_logger_t *lg = arena_logger_registry; lg; lg = lg->next) {
+        if (!lg->giveback_log_count) continue;
+        arena_t *a = lg->arena;
+        const char *sub = a && a->meta.lifetime_owner ? "(sub)" : "";
+        char cap_str[32];
+        al__fmt_bytes(lg->capacity, cap_str, sizeof(cap_str));
+        fprintf(f, "--- %s:%d %s (%s, %u givebacks) ---\n",
+                lg->init_file ? lg->init_file : "?", lg->init_line, sub, cap_str, lg->giveback_log_count);
+        al__write_giveback_log(f, a);
+    }
+
+    fclose(f);
+}
+
+void arena_logger_dump_json_simple(const char *filepath)
+{
+    FILE *f = fopen(filepath, "w");
+    if (!f) {
+        fprintf(stderr, "[arena_logger] Failed to open '%s' for writing\n", filepath);
+        return;
+    }
+
+    fprintf(f, "[\n");
+    bool first = true;
+    for (arena_logger_t *lg = arena_logger_registry; lg; lg = lg->next) {
+        arena_t *a = lg->arena;
+        u64 flb = a ? al__fl_bytes(a) : 0;
+        u64 used = a ? a->size : 0;
+        u64 unused = lg->capacity > used ? lg->capacity - used : 0;
+
+        if (!first) fprintf(f, ",\n");
+        first = false;
+
+        fprintf(f, "  {\n");
+        fprintf(f, "    \"file\": \"%s\",\n", lg->init_file ? lg->init_file : "?");
+        fprintf(f, "    \"line\": %d,\n", lg->init_line);
+        fprintf(f, "    \"capacity\": %lu,\n", (unsigned long)lg->capacity);
+        fprintf(f, "    \"used\": %lu,\n", (unsigned long)used);
+        fprintf(f, "    \"unused\": %lu,\n", (unsigned long)unused);
+        fprintf(f, "    \"alloc_count\": %u,\n", lg->alloc_log_count);
+        fprintf(f, "    \"giveback_count\": %u,\n", lg->giveback_log_count);
+        fprintf(f, "    \"freelist_chunks\": %u,\n", a ? a->freelist.count : 0);
+        fprintf(f, "    \"freelist_bytes\": %lu,\n", (unsigned long)flb);
+        fprintf(f, "    \"freelist_used_pct\": %.2f\n", lg->capacity ? ((double)flb / (double)lg->capacity) * 100.0 : 0.0);
+        fprintf(f, "  }");
+    }
+    fprintf(f, "\n]\n");
+    fclose(f);
 }
 
 #endif

--- a/basic/arena_logger.h
+++ b/basic/arena_logger.h
@@ -46,14 +46,27 @@ struct arena_alloc_record {
     arena_alloc_record_t *next;
 };
 
+typedef struct arena_giveback_record arena_giveback_record_t;
+struct arena_giveback_record {
+    const char          *file;
+    int                  line;
+    const char          *func;
+    uint64_t             size;
+    char                *backtrace_frames[ARENA_BACKTRACE_DEPTH];
+    u32                  backtrace_count;
+    arena_giveback_record_t *next;
+};
+
 typedef struct arena_logger_t arena_logger_t;
 struct arena_logger_t {
     arena_t            *arena;
     uint64_t            capacity;
     const char          *init_file;
     int                 init_line;
-    arena_alloc_record_t *alloc_log_head;
-    uint32_t             alloc_log_count;
+    arena_alloc_record_t    *alloc_log_head;
+    uint32_t                 alloc_log_count;
+    arena_giveback_record_t *giveback_log_head;
+    uint32_t                 giveback_log_count;
     arena_logger_t      *next;
 };
 
@@ -62,8 +75,11 @@ extern arena_logger_t *arena_logger_registry;
 void    arena_logger_init(arena_t *const arena, uint64_t capacity, const char *file, int line);
 void    arena_logger_destroy(arena_t *const arena);
 void    arena_logger_log_alloc(arena_t *const arena, uint64_t size, const char *file, int line, const char *func);
+void    arena_logger_log_giveback(arena_t *const arena, uint64_t size, const char *file, int line, const char *func);
 void    arena_logger_clear_log(arena_t *const arena);
 void    arena_logger_dump_json(const char *filepath);
+void    arena_logger_dump_summary(const char *filepath);
+void    arena_logger_dump_json_simple(const char *filepath);
 
 #ifndef IGNORE_ARENA_LOGGER_IMPLEMENTATION
 
@@ -168,6 +184,69 @@ void arena_logger_log_alloc(arena_t *const arena, uint64_t size, const char *fil
     l->alloc_log_count++;
 }
 
+void arena_logger_log_giveback(arena_t *const arena, uint64_t size, const char *file, int line, const char *func)
+{
+    arena_logger_t *l = arena_logger__internal_find(arena);
+    if (!l) return;
+
+    arena_giveback_record_t *rec = (arena_giveback_record_t *)calloc(1, sizeof(*rec));
+    rec->file = file;
+    rec->line = line;
+    rec->func = func;
+    rec->size = size;
+
+#if defined(_WIN64)
+    {
+        void         *stack[ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1];
+        unsigned short frames = CaptureStackBackTrace(0, ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1, stack, NULL);
+        SYMBOL_INFO   *symbol = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + 256 * sizeof(char), 1);
+        symbol->MaxNameLen   = 255;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        HANDLE process = GetCurrentProcess();
+        SymInitialize(process, NULL, TRUE);
+
+        u32 count = 0;
+        for (int i = ARENA_BACKTRACE_SKIP + 1; i < (int)frames && count < ARENA_BACKTRACE_DEPTH; i++) {
+            if (SymFromAddr(process, (DWORD64)stack[i], 0, symbol)) {
+                rec->backtrace_frames[count] = (char *)calloc(256, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 255, "%s", symbol->Name);
+            } else {
+                rec->backtrace_frames[count] = (char *)calloc(32, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 31, "0x%p", stack[i]);
+            }
+            count++;
+        }
+        rec->backtrace_count = count;
+        free(symbol);
+    }
+#elif defined(__linux__)
+    {
+        void *array[ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1];
+        int frame_count = backtrace(array, ARENA_BACKTRACE_DEPTH + ARENA_BACKTRACE_SKIP + 1);
+        u32 count = 0;
+
+        for (int i = ARENA_BACKTRACE_SKIP + 1; i < frame_count && count < ARENA_BACKTRACE_DEPTH; i++) {
+            Dl_info info;
+            if (dladdr(array[i], &info) && info.dli_sname) {
+                rec->backtrace_frames[count] = (char *)calloc(256, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 255, "%s", info.dli_sname);
+            } else {
+                rec->backtrace_frames[count] = (char *)calloc(32, sizeof(char));
+                snprintf(rec->backtrace_frames[count], 31, "%p", array[i]);
+            }
+            count++;
+        }
+        rec->backtrace_count = count;
+    }
+#else
+    rec->backtrace_count = 0;
+#endif
+
+    rec->next = l->giveback_log_head;
+    l->giveback_log_head = rec;
+    l->giveback_log_count++;
+}
+
 void arena_logger_clear_log(arena_t *const arena)
 {
     arena_logger_t *l = arena_logger__internal_find(arena);
@@ -184,6 +263,18 @@ void arena_logger_clear_log(arena_t *const arena)
     }
     l->alloc_log_head = NULL;
     l->alloc_log_count = 0;
+
+    arena_giveback_record_t *gcur = l->giveback_log_head;
+    while (gcur) {
+        arena_giveback_record_t *next = gcur->next;
+        for (u32 i = 0; i < gcur->backtrace_count; i++) {
+            free(gcur->backtrace_frames[i]);
+        }
+        free(gcur);
+        gcur = next;
+    }
+    l->giveback_log_head = NULL;
+    l->giveback_log_count = 0;
 }
 
 static u32 arena_logger__internal_frame_lookup(const char *name, char fnames[][256], u32 *count)


### PR DESCRIPTION
## Summary

Extends the arena allocator's diagnostic infrastructure to make memory consumption data readable and actionable.

### Changes

**arena_logger.h:**
- Added `arena_giveback_record_t` struct and `giveback_log_head`/`giveback_log_count` fields to track every `arena_giveback` call with full backtrace
- Added `arena_logger_log_giveback()` function capturing caller file/line/func + backtrace (same pattern as alloc tracking)
- `arena_logger_clear_log()` now also cleans up giveback records

**arena.h:**
- `arena_giveback` is now a tracked macro (same pattern as `arena_reserve`) — callers automatically get file/line/func captured
- Internal impl renamed to `arena__internal_giveback` to avoid macro recursion
- Added `arena__internal__giveback_tracked()` wrapper that calls the raw impl + logger
- Implemented `arena_logger_dump_summary()` — generates a human-readable text table showing per-arena: capacity, used, unused, alloc count, giveback count, and freelist stats (chunks / bytes)
- Implemented `arena_logger_dump_json_simple()` — generates a flat JSON array (one object per arena) consumable by `jq` or scripts

**application.h:**
- Shutdown now also calls `arena_logger_dump_summary()` and `arena_logger_dump_json_simple()` alongside the existing speedscope JSON dump

### Purpose

The existing speedscope JSON dump was unreadable as raw data. These new outputs provide immediate visibility into:
- Which arenas are near capacity vs. have headroom
- How much memory sits in the freelist (fragmentation indicator)
- How many givebacks happen per arena (recycle activity)
- Per-arena alloc/giveback counts

This data directly informs decisions about freelist architecture (stack vs. list).